### PR TITLE
Fix compile error with GCC 15 (-std=c23)

### DIFF
--- a/internal/api/bool.h
+++ b/internal/api/bool.h
@@ -26,7 +26,7 @@ extern "C" {
 
 #ifndef LINUX_KERNEL
 
-#ifndef false
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ < 202311L && !defined(false)
 /* Boolean variable */
 enum { false, true };
 typedef _Bool bool;

--- a/internal/api/ext_headers.h
+++ b/internal/api/ext_headers.h
@@ -264,6 +264,7 @@ static const int errno_private = 0;
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -346,6 +347,7 @@ static inline int lc_get_time(time64_t *time_since_epoch)
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
When compiling on Fedora rawhide, it fails with:
```console
In file included from ../internal/api/atomic_bool.h:23,
                 from ../internal/api/mutex_w.h:24,
                 from ../drng/src/seeded_rng.c:28:
../internal/api/bool.h:31:8: error: cannot use keyword ‘false’ as enumeration constant
   31 | enum { false, true };
      |        ^~~~~
../internal/api/bool.h:31:8: note: ‘false’ is a keyword with ‘-std=c23’ onwards
../internal/api/bool.h:32:15: error: ‘bool’ cannot be defined via ‘typedef’
   32 | typedef _Bool bool;
      |               ^~~~
../internal/api/bool.h:32:15: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
../internal/api/bool.h:32:1: warning: useless type name in empty declaration
   32 | typedef _Bool bool;
      | ^~~~~~~
```
The first commit should fix it, though the second commit is just a cosmetics.