### PR TITLE
Make it compile without optional features

### DIFF
--- a/aead/tests/meson.build
+++ b/aead/tests/meson.build
@@ -122,7 +122,7 @@ if get_option('aes_cbc').enabled()
 	endif
 endif
 
-if get_option('hash_crypt').enabled()
+if get_option('hash_crypt').enabled() and get_option('ascon_keccak').enabled()
 
 	ascon_keccak_crypt_test = executable('ascon_keccak_crypt_test',
 				[ 'ascon_keccak_crypt_test.c', internal_src ],
@@ -162,11 +162,6 @@ if get_option('hash_crypt').enabled()
 				include_directories: [ include_internal_dirs ],
 				dependencies: leancrypto
 				)
-	ascon_crypt_wrong_algo = executable('ascon_crypt_wrong_algo',
-				[ 'ascon_crypt_wrong_algo.c', internal_src ],
-				include_directories: [ include_internal_dirs ],
-				dependencies: leancrypto
-				)
 	test('AEAD Ascon Keccak', ascon_keccak_crypt_test, suite: regression)
 	test('AEAD Ascon Keccak IUF', ascon_keccak_crypt_iuf_test, suite: regression)
 	test('AEAD Ascon Keccak 512 Accel large',
@@ -181,8 +176,6 @@ if get_option('hash_crypt').enabled()
 	test('AEAD Ascon Keccak 256 C large',
 	     ascon_keccak_crypt_large_test_256_c,
 	     timeout: 2500, is_parallel: false, suite: performance)
-	test('AEAD Ascon Error Handling', ascon_crypt_wrong_algo,
-	     suite: regression)
 endif
 
 if (get_option('hash_crypt').enabled() and get_option('ascon').enabled())
@@ -209,6 +202,11 @@ if (get_option('hash_crypt').enabled() and get_option('ascon').enabled())
 				include_directories: [ include_internal_dirs ],
 				dependencies: leancrypto
 				)
+	ascon_crypt_wrong_algo = executable('ascon_crypt_wrong_algo',
+				[ 'ascon_crypt_wrong_algo.c', internal_src ],
+				include_directories: [ include_internal_dirs ],
+				dependencies: leancrypto
+				)
 	test('AEAD Ascon C', ascon_crypt_test, suite: regression)
 	test('AEAD Ascon IUF C', ascon_crypt_iuf_test, suite: regression)
 	test('AEAD Ascon 128 Accel large',
@@ -217,4 +215,6 @@ if (get_option('hash_crypt').enabled() and get_option('ascon').enabled())
 	test('AEAD Ascon 128 C large',
 	     ascon_crypt_large_test_128_c,
 	     timeout: 2500, is_parallel: false, suite: performance)
+	test('AEAD Ascon Error Handling', ascon_crypt_wrong_algo,
+	     suite: regression)
 endif

--- a/ml-dsa/api/dilithium_helper.h
+++ b/ml-dsa/api/dilithium_helper.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+#ifdef LC_DILITHIUM_ED25519_SIG
+
 int lc_dilithium_ed25519_sig_load_partial(struct lc_dilithium_ed25519_sig *sig,
 					  const uint8_t *dilithium_src_sig,
 					  size_t dilithium_src_sig_len,
@@ -43,6 +45,7 @@ int lc_dilithium_ed25519_sk_load_partial(struct lc_dilithium_ed25519_sk *sk,
 					 size_t dilithium_src_key_len,
 					 const uint8_t *ed25519_src_key,
 					 size_t ed25519_src_key_len);
+#endif
 
 #ifdef __cplusplus
 }

--- a/ml-dsa/api/lc_dilithium_size.h.in
+++ b/ml-dsa/api/lc_dilithium_size.h.in
@@ -34,6 +34,7 @@
 #include "lc_hash.h"
 #include "lc_rng.h"
 #include "lc_sha3.h"
+#include "lc_sha512.h"
 
 #endif /* __ASSEMBLER__ */
 
@@ -652,7 +653,6 @@ int @dilithium_name@_verify_final(const struct @dilithium_name@_sig *sig,
 #ifdef LC_DILITHIUM_ED25519_SIG
 
 #include "lc_ed25519.h"
-#include "lc_sha512.h"
 
 /**
  * @brief Dilithium secret key


### PR DESCRIPTION
This is a minor adjustment to speed up the GnuTLS CI which builds leancrypto as a dependency. With this, it now builds with:

```console
meson setup build -Dascon=disabled -Dascon_keccak=disabled \
      -Dbike_5=disabled -Dbike_3=disabled -Dbike_1=disabled \
      -Dkyber_x25519=disabled -Ddilithium_ed25519=disabled \
      -Dx509_parser=disabled -Dx509_generator=disabled \
      -Dpkcs7_parser=disabled -Dpkcs7_generator=disabled
```