### PR TITLE
ML-DSA: properly skip RVV tests conditionally

### DIFF
--- a/ml-dsa/tests/dilithium_tester_iuf_riscv64_rvv.c
+++ b/ml-dsa/tests/dilithium_tester_iuf_riscv64_rvv.c
@@ -59,7 +59,7 @@ LC_TEST_FUNC(int, main, int argc, char *argv[])
 	(void)argv;
 
 	if (!(lc_cpu_feature_available() & LC_CPU_FEATURE_RISCV_ASM_RVV))
-		return -77;
+		return 77;
 
 	if (argc != 2)
 		return dilithium_tester_iuf_riscv64_rvv();

--- a/ml-dsa/tests/dilithium_tester_riscv64_rvv.c
+++ b/ml-dsa/tests/dilithium_tester_riscv64_rvv.c
@@ -54,7 +54,7 @@ LC_TEST_FUNC(int, main, int argc, char *argv[])
 	(void)argv;
 
 	if (!(lc_cpu_feature_available() & LC_CPU_FEATURE_RISCV_ASM_RVV))
-		return -77;
+		return 77;
 
 	if (argc != 2)
 		return dilithium_tester_riscv64_rvv();


### PR DESCRIPTION
`return -77` should be `return 77`, as everywhere else.