### PR TITLE
ML-KEM: check CPU features before calling kyber_rvv_selector

### DIFF
--- a/ml-kem/src/riscv64/kyber_rvv_vlen_selector.c
+++ b/ml-kem/src/riscv64/kyber_rvv_vlen_selector.c
@@ -17,6 +17,7 @@
  * DAMAGE.
  */
 
+#include "cpufeatures.h"
 #include "ext_headers_riscv.h"
 #include "initialization.h"
 #include "kyber_rvv_vlen_selector.h"
@@ -28,9 +29,11 @@ static int lc_riscv_rvv_vlen = 0;
 
 LC_CONSTRUCTOR(kyber_riscv_rvv_selector)
 {
-	LC_VECTOR_ENABLE;
-	lc_riscv_rvv_vlen = kyber_rvv_selector();
-	LC_VECTOR_DISABLE;
+	if (lc_cpu_feature_available() & LC_CPU_FEATURE_RISCV_ASM_RVV) {
+		LC_VECTOR_ENABLE;
+		lc_riscv_rvv_vlen = kyber_rvv_selector();
+		LC_VECTOR_DISABLE;
+	}
 }
 
 int lc_riscv_rvv_is_vlen128(void)


### PR DESCRIPTION
On RISC-V platforms without V, kyber_rvv_selector is called first in `__attribute__((constructor))` before the normal dynamic dispatch code in kyber_kem_api_riscv.c, causing SIGILL. Add a condition so that lc_cpu_feature_available() is always first checked.