### PR TITLE
Compile FIPS 140 integrity check only when building shared library

### DIFF
--- a/.github/workflows/compile-pqc-only.yml
+++ b/.github/workflows/compile-pqc-only.yml
@@ -11,14 +11,18 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        default-library: ['shared', 'static', 'both']
+
     steps:
     - uses: actions/checkout@v3
     - name: Install meson
       run: |
         sudo apt-get update
         sudo apt-get install -y meson
-    - name: Meson setup
-      run: meson setup build -Dascon=disabled -Dascon_keccak=disabled -Dbike_5=disabled -Dbike_3=disabled -Dbike_1=disabled -Dkyber_x25519=disabled -Ddilithium_ed25519=disabled -Dx509_parser=disabled -Dx509_generator=disabled -Dpkcs7_parser=disabled -Dpkcs7_generator=disabled -Dsha2-256=disabled -Dsha2-512=disabled -Dchacha20=disabled -Dchacha20_drng=disabled -Ddrbg_hash=disabled -Ddrbg_hmac=disabled -Dhash_crypt=disabled -Dhmac=disabled -Dhkdf=disabled -Dkdf_ctr=disabled -Dkdf_fb=disabled -Dkdf_dpi=disabled -Dpbkdf2=disabled -Dkmac_drng=disabled -Dcshake_drng=disabled -Dhotp=disabled -Dtotp=disabled -Daes_block=disabled -Daes_cbc=disabled -Daes_ctr=disabled -Daes_kw=disabled -Dapps=disabled
+    - name: Meson setup ${{ matrix.default-library }}
+      run: meson setup build -Dascon=disabled -Dascon_keccak=disabled -Dbike_5=disabled -Dbike_3=disabled -Dbike_1=disabled -Dkyber_x25519=disabled -Ddilithium_ed25519=disabled -Dx509_parser=disabled -Dx509_generator=disabled -Dpkcs7_parser=disabled -Dpkcs7_generator=disabled -Dsha2-256=disabled -Dsha2-512=disabled -Dchacha20=disabled -Dchacha20_drng=disabled -Ddrbg_hash=disabled -Ddrbg_hmac=disabled -Dhash_crypt=disabled -Dhmac=disabled -Dhkdf=disabled -Dkdf_ctr=disabled -Dkdf_fb=disabled -Dkdf_dpi=disabled -Dpbkdf2=disabled -Dkmac_drng=disabled -Dcshake_drng=disabled -Dhotp=disabled -Dtotp=disabled -Daes_block=disabled -Daes_cbc=disabled -Daes_ctr=disabled -Daes_kw=disabled -Dapps=disabled -Ddefault_library=${{ matrix.default-library }}
     - name: Meson compile
       run: meson compile -C build
     - name: Meson test

--- a/internal/src/meson.build
+++ b/internal/src/meson.build
@@ -33,7 +33,7 @@ else
 endif
 
 # FIPS 140 Integrity check: The integrity checker is adopted for ELF.
-if (host_machine.system() == 'linux' and get_option('efi').disabled())
+if (host_machine.system() == 'linux' and get_option('efi').disabled() and build_shared)
 	src_fips_wrapper += files([
 		'fips_integrity_checker_elf.c'
 	])

--- a/meson.build
+++ b/meson.build
@@ -631,6 +631,10 @@ leancrypto_support_libs_fips = [ ]
 # External libraries leancrypto should link to
 leancrypto_link = [ ]
 
+# Whether to build the shared library alongside the static library
+build_shared = (get_option('default_library') != 'static' and
+		get_option('efi').disabled())
+
 foreach n : subdirs
 	subdir(n)
 endforeach
@@ -650,10 +654,6 @@ if (host_machine.system() != 'windows')
 		    check: true)
 endif
 
-# Whether to build the shared library alongside the static library
-build_shared = (get_option('default_library') != 'static' and
-		get_option('efi').disabled())
-
 # Compile the "raw" FIPS 140 library part which can be linked into
 # the libleancrypto-fips.[so|a] with the integrity test as well as
 # non-FIPS libleancrypto.[so|a] without the integrity test.
@@ -671,7 +671,7 @@ fips_integrity_checker_values_h = []
 link_args_fips140 = []
 
 # FIPS 140 Integrity check: The integrity checker is adopted for ELF.
-if (host_machine.system() == 'linux' and get_option('efi').disabled())
+if (host_machine.system() == 'linux' and get_option('efi').disabled() and build_shared)
 	link_args_fips140 = [
 		'-T' + meson.project_source_root() + '/internal/src/fips_integrity_check.ld'
 	]


### PR DESCRIPTION
When leancrypto is compiled as a static library with
`-Ddefault_library=static`, it fails with:

```
../internal/src/fips_integrity_checker_elf.c:77:10: fatal error: fips_integrity_checker_values.h: No such file or directory
   77 | #include "fips_integrity_checker_values.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Given the FIPS 140 integrity check only works with shared library, as
it utilizes the ELF sections, this adds an extra check on
build_shared to avoid the compilation error.

Originally spotted by GnuTLS CI at: https://gitlab.com/dueno/gnutls/-/jobs/9425635915#L509