### PR TITLE
fix: add `PartialEq` trait to `HashError` to fix failing assertions

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,4 +1,5 @@
 #[derive(Debug)]
+#[derive(PartialEq)]
 pub enum HashError {
     AllocationError,
     UninitializedContext,


### PR DESCRIPTION
This PR fixes bug causing failed assertions while running unit tests. The fix comes from adding the `PartialEq` trait to the `HashError` enum.