### PR TITLE
gitignore: Add kernel module build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@
 build
 Cargo.lock
 target
+
+*.cmd
+*.o
+*.ko
+*.mod
+*.mod.c
+*.mod.o
+modules.order
+Module.symvers
+
+linux_kernel/lc_*.h


### PR DESCRIPTION
The kernel module build process, driven by kbuild, generates a number of intermediate object files, dependency files, and final artifacts in the source tree.

These generated files should not be tracked in the Git repository. Add common patterns for these files to the root .gitignore to keep the project tree clean and prevent them from being accidentally committed.

This includes:
- Object (.o) and final kernel module (.ko) files
- Kbuild dependency (.cmd) and module metadata files (.mod, .mod.c, modules.order, Module.symvers)
- Project-specific generated headers (lc_*.h)