### PR TITLE
License: BSD 3-clause license applied to ASN.1/X.509/PKCS7

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -346,9 +346,14 @@ SPDX-License-Identifier: GPL-2.0-or-later
 Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
 Written by David Howells (dhowells@redhat.com)
 
+Red Hat granted the following additional license to the leancrypto project:
+SPDX-License-Identifier: BSD-3-Clause
+
 The following files are affected:
 
+asn1/api/lc_asn1.h
 asn1/src/asn1_ber_bytecode.h
+asn1/src/asn1_common.c
 asn1/src/asn1_compiler.c
 asn1/src/asn1_decoder.c
 asn1/src/asn1_decoder.h

--- a/asn1/api/lc_asn1.h
+++ b/asn1/api/lc_asn1.h
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #ifndef LC_ASN1_H
 #define LC_ASN1_H

--- a/asn1/src/asn1.h
+++ b/asn1/src/asn1.h
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #ifndef ASN1_H
 #define ASN1_H

--- a/asn1/src/asn1_ber_bytecode.h
+++ b/asn1/src/asn1_ber_bytecode.h
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #ifndef ASN1_BER_BYTECODE_H
 #define ASN1_BER_BYTECODE_H

--- a/asn1/src/asn1_common.c
+++ b/asn1/src/asn1_common.c
@@ -16,6 +16,17 @@
  * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
  * DAMAGE.
  */
+/*
+ * This code is derived in parts from the Linux kernel
+ * License: SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
+ * Written by David Howells (dhowells@redhat.com)
+ */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1_ber_bytecode.h"
 

--- a/asn1/src/asn1_compiler.c
+++ b/asn1/src/asn1_compiler.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/asn1/src/asn1_decoder.c
+++ b/asn1/src/asn1_decoder.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1_debug.h"
 #include "asn1_decoder.h"

--- a/asn1/src/asn1_decoder.h
+++ b/asn1/src/asn1_decoder.h
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #ifndef ASN1_DECODER_H
 #define ASN1_DECODER_H

--- a/asn1/src/asymmetric_type.c
+++ b/asn1/src/asymmetric_type.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asymmetric_type.h"
 #include "build_bug_on.h"

--- a/asn1/src/asymmetric_type.h
+++ b/asn1/src/asymmetric_type.h
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #ifndef ASYMMETRIC_TYPE_H
 #define ASYMMETRIC_TYPE_H

--- a/asn1/src/build_OID_registry
+++ b/asn1/src/build_OID_registry
@@ -23,6 +23,10 @@
 # Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
 # Written by David Howells (dhowells@redhat.com)
 #
+#
+#cRed Hat granted the following additional license to the leancrypto project:
+# SPDX-License-Identifier: BSD-3-Clause
+#
 
 use strict;
 use Cwd qw(abs_path);

--- a/asn1/src/oid_registry.c
+++ b/asn1/src/oid_registry.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1.h"
 #include "ext_headers_internal.h"

--- a/asn1/src/oid_registry.h
+++ b/asn1/src/oid_registry.h
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #ifndef OID_REGISTRY_H
 #define OID_REGISTRY_H

--- a/asn1/src/pkcs7_parser.c
+++ b/asn1/src/pkcs7_parser.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1_debug.h"
 #include "ext_headers_internal.h"

--- a/asn1/src/pkcs7_trust.c
+++ b/asn1/src/pkcs7_trust.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1_debug.h"
 #include "asym_key.h"

--- a/asn1/src/pkcs7_verify.c
+++ b/asn1/src/pkcs7_verify.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1.h"
 #include "asn1_debug.h"

--- a/asn1/src/x509_cert_parser.c
+++ b/asn1/src/x509_cert_parser.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "lc_memcmp_secure.h"
 #include "lc_memory_support.h"

--- a/asn1/src/x509_public_key.c
+++ b/asn1/src/x509_public_key.c
@@ -23,6 +23,10 @@
  * Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
  * Written by David Howells (dhowells@redhat.com)
  */
+/*
+ * Red Hat granted the following additional license to the leancrypto project:
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1_debug.h"
 #include "lc_memcmp_secure.h"


### PR DESCRIPTION
Red Hat generously granted the BSD 3-clause license to the ASN.1/X.509/PKCS7 code base derived from the Linux kernel and used in leancrypto.