### PR TITLE
License: BSD 3-clause license applied to ASN.1 helper

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -392,6 +392,9 @@ License: SPDX-License-Identifier: GPL-2.0-only
 
 Copyright (C) 2019 James.Bottomley@HansenPartnership.com
 
+James Bottomley granted the following additional license to the leancrypto
+project: SPDX-License-Identifier: BSD-3-Clause
+
 The following files are affected:
 
 asn1/src/asn1_encoder_helper.c

--- a/asn1/src/asn1_encoder_helper.c
+++ b/asn1/src/asn1_encoder_helper.c
@@ -22,6 +22,10 @@
  *
  * Copyright (C) 2019 James.Bottomley@HansenPartnership.com
  */
+/*
+ * James Bottomley granted the following additional license to the leancrypto
+ * project: SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "asn1_debug.h"
 #include "asn1_encoder.h"


### PR DESCRIPTION
James Bottomley generously granted the BSD 3-clause license to the ASN.1 heloer code base derived from the Linux kernel and used in leancrypto.