### PR TITLE
SLH-DSA: guard ARMv8 backend on non-AArch64 builds

### DIFF
--- a/slh-dsa/src/sphincs_sign.c
+++ b/slh-dsa/src/sphincs_sign.c
@@ -51,9 +51,11 @@
 #include "avx2/sphincs_merkle_avx2.h"
 #include "avx2/sphincs_wots_avx2.h"
 
+#if defined(LC_HOST_AARCH64)
 #include "armv8/sphincs_fors_armv8.h"
 #include "armv8/sphincs_merkle_armv8.h"
 #include "armv8/sphincs_wots_armv8.h"
+#endif
 
 struct lc_sphincs_func_ctx {
 	merkle_sign_f merkle_sign;
@@ -79,6 +81,7 @@ static const struct lc_sphincs_func_ctx f_ctx_avx2 __maybe_unused = {
 	.wots_pk_from_sig = wots_pk_from_sig_avx2,
 };
 
+#if defined(LC_HOST_AARCH64)
 static const struct lc_sphincs_func_ctx f_ctx_armv8 __maybe_unused = {
 	.merkle_sign = sphincs_merkle_sign_armv8,
 	.merkle_gen_root = sphincs_merkle_gen_root_armv8,
@@ -86,6 +89,7 @@ static const struct lc_sphincs_func_ctx f_ctx_armv8 __maybe_unused = {
 	.fors_pk_from_sig = fors_pk_from_sig_armv8,
 	.wots_pk_from_sig = wots_pk_from_sig_armv8,
 };
+#endif
 
 static const struct lc_sphincs_func_ctx *lc_sphincs_get_ctx(void)
 {


### PR DESCRIPTION
## Summary
- guard the ARMv8 SPHINCS includes and backend function table with `LC_HOST_AARCH64`
- keep the non-AArch64 build from exposing `*_armv8` references to the linker when LTO is enabled
- match the compile-time visibility of the ARMv8 backend with the existing runtime dispatch conditions

## Build Failure Context
This fixes a Gentoo x86_64 build failure with LTO enabled where `slh-dsa/src/sphincs_sign.c` still contributed ARMv8-only references from the static backend table on a non-AArch64 build.

The failing link showed unresolved symbols from `.data.rel.ro`, e.g.:
- `undefined reference to lc_sphincs_shake_192s_sphincs_merkle_sign_armv8`
- `undefined reference to lc_sphincs_shake_192s_fors_pk_from_sig_armv8`
- `undefined reference to lc_sphincs_shake_128f_wots_pk_from_sig_armv8`

The issue is that `f_ctx_armv8` is defined unconditionally even though the ARMv8 path is only selected under `LC_HOST_AARCH64`. Without the compile-time guard, LTO can keep those ARMv8 function pointer references alive on x86_64 and fail the final link.