### PR TITLE
Linux kernel: leancrypto_kernel_rng_tester: include linux/hex.h

### DIFF
--- a/drng/tests/leancrypto_kernel_rng_tester.c
+++ b/drng/tests/leancrypto_kernel_rng_tester.c
@@ -20,6 +20,7 @@
 
 #include <crypto/rng.h>
 #include <linux/err.h>
+#include <linux/hex.h>
 #include <linux/module.h>
 
 static int lc_seeded_rng_test(void)


### PR DESCRIPTION
Since commit [24c776355f40 ("kernel.h: drop hex.h and update all hex.h users")](https://github.com/torvalds/linux//commit/24c776355f40), `hex.h` is not included from `kernel.h`. It needs to be included in each file using the functions. That is the case in `leancrypto_kernel_rng_tester`:
```
 ../drng/tests/leancrypto_kernel_rng_tester.c: In function ‘lc_seeded_rng_test’:
 ../drng/tests/leancrypto_kernel_rng_tester.c:43:9: error: implicit declaration of function ‘bin2hex’ [-Wimplicit-function-declaration]
    43 |         bin2hex(hex, outbuf, sizeof(outbuf));
       |         ^~~~~~~
```