### PR TITLE
sunOS: use seeded_rng_bsd.c on sunOS & derivs ☀️✨

### DIFF
--- a/drng/src/meson.build
+++ b/drng/src/meson.build
@@ -118,7 +118,8 @@ if (seeded_rng == 1)
 
 		if ((host_machine.system() == 'dragonfly') or
 		    (host_machine.system() == 'freebsd') or
-		    (host_machine.system() == 'openbsd'))
+		    (host_machine.system() == 'openbsd') or
+		    (host_machine.system() == 'sunos'))
 			src += files([ 'seeded_rng_bsd.c' ])
 		endif
 


### PR DESCRIPTION
sunOS (and solaris, illumos, and friends) uses the same getentropy API endpoint as the BSDs. BSD support can be reused.

I am running `meson test` atm, will update when done.