### PR TITLE
ChaCha20: Align lc_sym_state to at least 4 bytes to fix m68k

### DIFF
--- a/sym/api/lc_chacha20_private.h
+++ b/sym/api/lc_chacha20_private.h
@@ -39,8 +39,12 @@ extern "C" {
  * For accelerated ChaCha20 implementatinos, the key and the counter must be
  * aligned to 16 bytes boundary. This is guaranteed when aligning the entire
  * structure to 16 bytes as the constant field is 16 bytes in size.
+ *
+ * Force at least 4-byte alignment so that sizeof(struct lc_sym_state) is
+ * consistent (132) on architectures where uint32_t has only 2-byte alignment
+ * (e.g. m68k without -malign-int).
  */
-struct lc_sym_state {
+struct __attribute__((aligned(4))) lc_sym_state {
 	uint32_t constants[4];
 	union {
 		uint32_t u[LC_CC20_KEY_SIZE_WORDS];


### PR DESCRIPTION
m68k aligns to 2 bytes by default.

I have successfully run the tests on m68k and x86_64 (as 64-bit and 32-bit).