### PR TITLE
(void)ctx references undeclared identifier in Dilithium-EdDSA helpers

### DIFF
--- a/asn1/src/asym_key_dilithium_ed25519.c
+++ b/asn1/src/asym_key_dilithium_ed25519.c
@@ -198,7 +198,7 @@ out:
 #else
 	(void)data;
 	(void)avail_datalen;
-	(void)ctx;
+	(void)key;
 	return -EOPNOTSUPP;
 #endif
 }

--- a/asn1/src/asym_key_dilithium_ed448.c
+++ b/asn1/src/asym_key_dilithium_ed448.c
@@ -208,7 +208,7 @@ out:
 #else
 	(void)data;
 	(void)avail_datalen;
-	(void)ctx;
+	(void)key;
 	return -EOPNOTSUPP;
 #endif
 }


### PR DESCRIPTION
## Summary

Two functions in leancrypto's asymmetric key handling code have a typo
in their `#else` stub: they cast a non-existent identifier `ctx` to
`void`, when the actual parameter name is `key`. The error is invisible
under the default build because `LC_X509_GENERATOR` is defined, but it
surfaces immediately when `CONFIG_LEANCRYPTO_X509_GENERATOR` is disabled.

```
asn1/src/asym_key_dilithium_ed25519.c: In function
   'public_key_encode_dilithium_ed25519':
asn1/src/asym_key_dilithium_ed25519.c:201:15: error: 'ctx' undeclared
   (first use in this function)
  201 |         (void)ctx;
      |               ^~~

asn1/src/asym_key_dilithium_ed448.c: In function
   'public_key_encode_dilithium_ed448':
asn1/src/asym_key_dilithium_ed448.c:211:15: error: 'ctx' undeclared
   (first use in this function)
  211 |         (void)ctx;
      |               ^~~
```

## Root cause

Both `public_key_encode_dilithium_ed25519()` and
`public_key_encode_dilithium_ed448()` take a third parameter named `key`
(of type `const struct lc_x509_key_data *`). Their `#ifdef LC_X509_GENERATOR`
/ `#else` stubs need to silence unused-parameter warnings for `data`,
`avail_datalen`, and `key`, but they incorrectly write `(void)ctx;` for
the third one 

The `#else` branch is dead code as long as `LC_X509_GENERATOR` is
defined, which is the default and is silently active in the in-tree
build path. Once that macro is undefined (e.g. by disabling
`CONFIG_LEANCRYPTO_X509_GENERATOR`), the typo prevents compilation.

## Scope

`asn1/src/asym_key_dilithium_ed25519.c` (one occurrence, line ~201)
`asn1/src/asym_key_dilithium_ed448.c`  (one occurrence, line ~211)

The matching `private_key_encode_*` functions in the same files are
correct - their parameter genuinely is `ctx`. Only the
`public_key_encode_*` stubs are wrong.

I also spot-checked the other `asym_key_*` files in `asn1/src/`
(`asym_key_dilithium.c`, `asym_key_sphincs.c`, `asym_key_ed25519.c`,
`asym_key_ed448.c`); they are consistent and not affected.

## Reproduction

In `linux_kernel/Kbuild.config`:

```
# CONFIG_LEANCRYPTO_X509_GENERATOR=y
```

Build. Compilation fails on both files above.

## Fix

Replace `(void)ctx;` with `(void)key;` in both stubs.
