### PR TITLE
Fix Windows DLL linking issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@ Changes 1.8.1-prerelease
 
 * Windows: fix SHA-3 / SHAKE / cSHAKE acceleration - the assembler implementations were handed over to the glue code as function pointers that did not carry the SysV ABI, i.e. the indirect calls were issued with the ABI of the host.
 
+* Windows: fix SHA-2 acceleration - the AVX2 and SHA-NI implementations were neither declared nor handed over to the glue code with the SysV ABI.
+
 Changes 1.8.0
 * X.509: provide a common automated serial number generator which is the 20 leftmost bytes of the SHA3-256 hash of the certificate DER blob with the serial number being 20 bytes of 0xff and the signature part equally a range of 0xff bytes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Changes 1.8.1-prerelease
 
 * Windows: fix parallel compilation of the assembler code that is compiled once per ML-KEM / ML-DSA parameter set - clang-cl placed the preprocessed intermediate of all of them into the same file.
 
+* Windows: fix linking against the shared library - the import libraries referenced a non-existing DLL name and the exported data symbols were neither marked as DATA nor declared with __declspec(dllimport).
+
 Changes 1.8.0
 * X.509: provide a common automated serial number generator which is the 20 leftmost bytes of the SHA3-256 hash of the certificate DER blob with the serial number being 20 bytes of 0xff and the signature part equally a range of 0xff bytes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ Changes 1.8.1-prerelease
 
 * Add support for native Windows with MSVC using clang-cl (the MSVC compiler is not supported as the assembler structure is different and I am not going to support multiple ASM structures).
 
+* Windows: fix parallel compilation of the assembler code that is compiled once per ML-KEM / ML-DSA parameter set - clang-cl placed the preprocessed intermediate of all of them into the same file.
+
 Changes 1.8.0
 * X.509: provide a common automated serial number generator which is the 20 leftmost bytes of the SHA3-256 hash of the certificate DER blob with the serial number being 20 bytes of 0xff and the signature part equally a range of 0xff bytes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Changes 1.8.1-prerelease
 
 * Windows: fix linking against the shared library - the import libraries referenced a non-existing DLL name and the exported data symbols were neither marked as DATA nor declared with __declspec(dllimport).
 
+* Windows: fix SHA-3 / SHAKE / cSHAKE acceleration - the assembler implementations were handed over to the glue code as function pointers that did not carry the SysV ABI, i.e. the indirect calls were issued with the ABI of the host.
+
 Changes 1.8.0
 * X.509: provide a common automated serial number generator which is the 20 leftmost bytes of the SHA3-256 hash of the certificate DER blob with the serial number being 20 bytes of 0xff and the signature part equally a range of 0xff bytes
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ Now you are ready to set up `leancrypto` with meson:
 
 3. `meson compile -C build`
 
+Applications linking against the `leancrypto` DLL must be compiled with
+`-DLC_LINK_SHARED`. It makes the header files declare the exported data symbols
+such as `lc_sha3_256` with `__declspec(dllimport)` which Windows requires to
+resolve them through the import table. The generated `pkg-config` file carries
+the definition, i.e. consumers using `pkg-config` get it automatically. It must
+not be set when linking against the static library.
+
 ### MSYS2
 
 The `leancrypto` library can be built on Windows using

--- a/aead/api/lc_aes_gcm.h
+++ b/aead/api/lc_aes_gcm.h
@@ -20,6 +20,7 @@
 #ifndef LC_AES_GCM_H
 #define LC_AES_GCM_H
 
+#include "lc_export.h"
 #include "lc_aead.h"
 #include "lc_aes.h"
 #include "lc_sym.h"
@@ -70,7 +71,7 @@ struct lc_aes_gcm_cryptor {
 	(LC_AES_GCM_CTX_COMMON_SIZE + LC_AES_GCM_STATE_SIZE_LEN(len))
 
 /* AES-GCM AEAD-algorithm */
-extern const struct lc_aead *lc_aes_gcm_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_aes_gcm_aead;
 
 #define _LC_AES_GCM_SET_CTX(name)                                              \
 	_LC_SYM_SET_CTX((&name->sym_ctx), lc_aes, name,                        \

--- a/aead/api/lc_ascon_keccak.h
+++ b/aead/api/lc_ascon_keccak.h
@@ -20,6 +20,7 @@
 #ifndef LC_ASCON_KECCAK_H
 #define LC_ASCON_KECCAK_H
 
+#include "lc_export.h"
 #include "lc_ascon_aead.h"
 #include "lc_sha3.h"
 
@@ -42,7 +43,7 @@ extern "C" {
 /// \endcond
 
 /* Ascon-Keccak-based AEAD-algorithm */
-extern const struct lc_aead *lc_ascon_keccak_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_ascon_keccak_aead;
 
 /**
  * @brief Allocate Ascon Keccak cryptor context on heap

--- a/aead/api/lc_ascon_lightweight.h
+++ b/aead/api/lc_ascon_lightweight.h
@@ -20,6 +20,7 @@
 #ifndef LC_ASCON_LIGHTWEIGHT_H
 #define LC_ASCON_LIGHTWEIGHT_H
 
+#include "lc_export.h"
 #include "lc_ascon_aead.h"
 #include "lc_ascon_hash.h"
 
@@ -42,7 +43,7 @@ extern "C" {
 /// \endcond
 
 /* Ascon-based AEAD-algorithm */
-extern const struct lc_aead *lc_ascon_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_ascon_aead;
 
 /**
  * @brief Allocate Ascon Lightweight cryptor context on heap

--- a/aead/api/lc_chacha20_poly1305.h
+++ b/aead/api/lc_chacha20_poly1305.h
@@ -20,6 +20,7 @@
 #ifndef LC_CHACHA20_POLY1305_H
 #define LC_CHACHA20_POLY1305_H
 
+#include "lc_export.h"
 #include "lc_aead.h"
 #include "lc_chacha20.h"
 #include "lc_memset_secure.h"
@@ -46,7 +47,7 @@ struct lc_chacha20_poly1305_cryptor {
 	 LC_CHACHA20_POLY1305_STATE_SIZE)
 
 /* AES-CBC with HMAC based AEAD-algorithm */
-extern const struct lc_aead *lc_chacha20_poly1305_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_chacha20_poly1305_aead;
 
 #define _LC_CHACHA20_POLY1305_SET_CTX(name)                                    \
 	_LC_SYM_SET_CTX((&name->chacha20), lc_chacha20, name,                  \

--- a/aead/api/lc_cshake_crypt.h
+++ b/aead/api/lc_cshake_crypt.h
@@ -20,6 +20,7 @@
 #ifndef LC_CSHAKE_CRYPT_H
 #define LC_CSHAKE_CRYPT_H
 
+#include "lc_export.h"
 #include "lc_aead.h"
 #include "lc_memory_support.h"
 
@@ -70,7 +71,7 @@ struct lc_cc_cryptor {
 	 LC_CC_STATE_SIZE)
 
 /* CSHAKE-based AEAD-algorithm */
-extern const struct lc_aead *lc_cshake_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_cshake_aead;
 
 /* Ensure that ->keystream is aligned to XOR alignment requirement */
 #define _LC_CC_SET_CTX(name, hashname)                                         \

--- a/aead/api/lc_hash_crypt.h
+++ b/aead/api/lc_hash_crypt.h
@@ -20,6 +20,7 @@
 #ifndef LC_HASH_CRYPT_H
 #define LC_HASH_CRYPT_H
 
+#include "lc_export.h"
 #include "lc_aead.h"
 /*
  * This is the hash crypt cipher operation using the Hash DRBG with SHA-512
@@ -59,7 +60,7 @@ struct lc_hc_cryptor {
 	 LC_HASH_COMMON_ALIGNMENT)
 
 /* Hash-based AEAD-algorithm */
-extern const struct lc_aead *lc_hash_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_hash_aead;
 
 #define _LC_HC_SET_CTX(name, hashname)                                         \
 	LC_DRBG_HASH_RNG_CTX((&name->drbg));                                   \

--- a/aead/api/lc_kmac_crypt.h
+++ b/aead/api/lc_kmac_crypt.h
@@ -20,6 +20,7 @@
 #ifndef LC_KMAC_CRYPT_H
 #define LC_KMAC_CRYPT_H
 
+#include "lc_export.h"
 #include "ext_headers.h"
 #include "lc_aead.h"
 #include "lc_memory_support.h"
@@ -68,7 +69,7 @@ struct lc_kc_cryptor {
 	 LC_KC_STATE_SIZE)
 
 /* KMAC-based AEAD-algorithm */
-extern const struct lc_aead *lc_kmac_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_kmac_aead;
 
 /* Ensure that ->keystream is aligned to XOR alignment requirement */
 #define _LC_KC_SET_CTX(name, hashname)                                         \

--- a/aead/api/lc_symhmac.h
+++ b/aead/api/lc_symhmac.h
@@ -20,6 +20,7 @@
 #ifndef LC_SYMHMAC_H
 #define LC_SYMHMAC_H
 
+#include "lc_export.h"
 #include "lc_aead.h"
 #include "lc_sym.h"
 #include "lc_hmac.h"
@@ -45,7 +46,7 @@ struct lc_sh_cryptor {
 	 LC_SH_STATE_SIZE + LC_HASH_COMMON_ALIGNMENT)
 
 /* AES-CBC with HMAC based AEAD-algorithm */
-extern const struct lc_aead *lc_symhmac_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_symhmac_aead;
 
 #define _LC_SH_SET_CTX(name, symalgo, hash)                                    \
 	_LC_SYM_SET_CTX((&name->sym), symalgo, name,                           \

--- a/aead/api/lc_symkmac.h
+++ b/aead/api/lc_symkmac.h
@@ -20,6 +20,7 @@
 #ifndef LC_SYMKMAC_H
 #define LC_SYMKMAC_H
 
+#include "lc_export.h"
 #include "lc_aead.h"
 #include "lc_sym.h"
 #include "lc_kmac.h"
@@ -45,7 +46,7 @@ struct lc_kh_cryptor {
 	 LC_KH_STATE_SIZE)
 
 /* AES-CBC with KMAC based AEAD-algorithm */
-extern const struct lc_aead *lc_symkmac_aead;
+extern LC_DLL_IMPORT const struct lc_aead *lc_symkmac_aead;
 
 #define _LC_KH_SET_CTX(name, symalgo, hash)                                    \
 	_LC_SYM_SET_CTX((&name->sym), symalgo, name,                           \

--- a/drng/api/lc_chacha20_drng.h
+++ b/drng/api/lc_chacha20_drng.h
@@ -20,6 +20,7 @@
 #ifndef _LC_CHACHA20_DRNG_H
 #define _LC_CHACHA20_DRNG_H
 
+#include "lc_export.h"
 #include "ext_headers.h"
 #include "lc_chacha20.h"
 #include "lc_rng.h"
@@ -39,7 +40,7 @@ struct lc_chacha20_drng_ctx {
 };
 
 /* ChaCha20-based DRNG */
-extern const struct lc_rng *lc_cc20_drng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_cc20_drng;
 
 #define LC_CC20_DRNG_SYM_STATE_SIZE (LC_CC20_STATE_SIZE)
 #define LC_CC20_DRNG_STATE_SIZE                                                \

--- a/drng/api/lc_cshake256_drng.h
+++ b/drng/api/lc_cshake256_drng.h
@@ -20,6 +20,7 @@
 #ifndef LC_CSHAKE256_DRNG_H
 #define LC_CSHAKE256_DRNG_H
 
+#include "lc_export.h"
 #include "lc_cshake.h"
 #include "lc_rng.h"
 
@@ -41,7 +42,7 @@ struct lc_cshake256_drng_state {
 	(sizeof(struct lc_rng_ctx) + LC_CSHAKE256_DRNG_STATE_SIZE)
 
 /* CSHAKE256-based DRNG */
-extern const struct lc_rng *lc_cshake256_drng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_cshake256_drng;
 
 #define LC_CSHAKE256_RNG_CTX(name)                                             \
 	LC_RNG_CTX(name, lc_cshake256_drng, 1);                                \

--- a/drng/api/lc_ctr_drbg.h
+++ b/drng/api/lc_ctr_drbg.h
@@ -20,6 +20,7 @@
 #ifndef LC_CTR_DRBG_H
 #define LC_CTR_DRBG_H
 
+#include "lc_export.h"
 #include "lc_aes.h"
 #include "lc_drbg.h"
 #include "lc_memory_support.h"
@@ -93,7 +94,7 @@ struct lc_drbg_ctr_state {
 	_LC_DRBG_CTR_SET_CTX(name, name, sizeof(struct lc_drbg_ctr_state),     \
 			     _use_df, _scratchpad_size)
 
-extern const struct lc_rng *lc_ctr_drbg;
+extern LC_DLL_IMPORT const struct lc_rng *lc_ctr_drbg;
 
 #define LC_DRBG_CTR_RNG_CTX(name, _use_df, _scratchpad_size)                   \
 	LC_RNG_CTX(name, lc_ctr_drbg, 1);                                      \

--- a/drng/api/lc_hash_drbg.h
+++ b/drng/api/lc_hash_drbg.h
@@ -20,6 +20,7 @@
 #ifndef LC_HASH_DRBG_H
 #define LC_HASH_DRBG_H
 
+#include "lc_export.h"
 #include "lc_drbg.h"
 #include "lc_rng.h"
 #include "lc_sha512.h"
@@ -57,7 +58,7 @@ struct lc_drbg_hash_state {
 #define LC_DRBG_HASH_SET_CTX(name)                                             \
 	_LC_DRBG_HASH_SET_CTX(name, name, sizeof(struct lc_drbg_hash_state))
 
-extern const struct lc_rng *lc_hash_drbg;
+extern LC_DLL_IMPORT const struct lc_rng *lc_hash_drbg;
 
 #define LC_DRBG_HASH_RNG_CTX(name)                                             \
 	LC_RNG_CTX((name), lc_hash_drbg, LC_HASH_COMMON_ALIGNMENT);            \

--- a/drng/api/lc_hmac_drbg.h
+++ b/drng/api/lc_hmac_drbg.h
@@ -20,6 +20,7 @@
 #ifndef LC_HMAC_DRBG_H
 #define LC_HMAC_DRBG_H
 
+#include "lc_export.h"
 #include "lc_drbg.h"
 #include "lc_hmac.h"
 #include "lc_rng.h"
@@ -58,7 +59,7 @@ struct lc_drbg_hmac_state {
 #define LC_DRBG_HMAC_SET_CTX(name)                                             \
 	_LC_DRBG_HMAC_SET_CTX(name, name, sizeof(struct lc_drbg_hmac_state))
 
-extern const struct lc_rng *lc_hmac_drbg;
+extern LC_DLL_IMPORT const struct lc_rng *lc_hmac_drbg;
 
 #define LC_DRBG_HMAC_RNG_CTX(name)                                             \
 	LC_RNG_CTX(name, lc_hmac_drbg, LC_HASH_COMMON_ALIGNMENT);              \

--- a/drng/api/lc_kmac256_drng.h
+++ b/drng/api/lc_kmac256_drng.h
@@ -20,6 +20,7 @@
 #ifndef LC_KMAC256_DRNG_H
 #define LC_KMAC256_DRNG_H
 
+#include "lc_export.h"
 #include "lc_kmac.h"
 #include "lc_rng.h"
 
@@ -41,7 +42,7 @@ struct lc_kmac256_drng_state {
 	(sizeof(struct lc_rng_ctx) + LC_KMAC256_DRNG_STATE_SIZE)
 
 /* KMAC256-based DRNG */
-extern const struct lc_rng *lc_kmac256_drng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_kmac256_drng;
 
 #define LC_KMAC256_RNG_CTX(name)                                               \
 	LC_RNG_CTX(name, lc_kmac256_drng, 1);                                  \

--- a/drng/api/lc_rng.h
+++ b/drng/api/lc_rng.h
@@ -20,6 +20,7 @@
 #ifndef LC_RNG_H
 #define LC_RNG_H
 
+#include "lc_export.h"
 #include "lc_memory_support.h"
 #include "lc_status.h"
 
@@ -72,7 +73,7 @@ struct lc_rng_ctx {
  * handled. Thus, this structure can be directly used for the lc_rng API by a
  * caller and have a properly seeded DRNG.
  */
-extern struct lc_rng_ctx *lc_seeded_rng;
+extern LC_DLL_IMPORT struct lc_rng_ctx *lc_seeded_rng;
 
 /**
  * @ingroup RNGs

--- a/drng/api/lc_xdrbg.h
+++ b/drng/api/lc_xdrbg.h
@@ -20,6 +20,8 @@
 #ifndef LC_XDRBG_DRNG_H
 #define LC_XDRBG_DRNG_H
 
+#include "lc_export.h"
+
 #if defined __has_include
 #if __has_include("lc_ascon_hash.h")
 #include "lc_ascon_hash.h"
@@ -77,8 +79,8 @@ struct lc_xdrbg_drng_state {
 #ifdef LC_XDRBG_SHAKE_ENABLED
 
 /// \cond DO_NOT_DOCUMENT
-extern const struct lc_rng *lc_xdrbg256_drng;
-extern const struct lc_rng *lc_xdrbg512_drng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_xdrbg256_drng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_xdrbg512_drng;
 
 #define LC_XDRBG256_DRNG_KEYSIZE 64
 /*
@@ -216,7 +218,7 @@ int lc_xdrbg512_drng_alloc(struct lc_rng_ctx **state);
 #ifdef LC_XDRBG_ASCON_ENABLED
 
 /// \cond DO_NOT_DOCUMENT
-extern const struct lc_rng *lc_xdrbg128_drng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_xdrbg128_drng;
 
 #define LC_XDRBG128_DRNG_KEYSIZE 32
 

--- a/hash/api/ascon_arm_neon.h
+++ b/hash/api/ascon_arm_neon.h
@@ -20,13 +20,15 @@
 #ifndef ASCON_ARM_NEON
 #define ASCON_ARM_NEON
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_ascon_256_arm_neon;
-extern const struct lc_hash *lc_ascon_128a_arm_neon;
-extern const struct lc_hash *lc_ascon_xof_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_256_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_128a_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_xof_arm_neon;
 
 #ifdef __cplusplus
 }

--- a/hash/api/ascon_avx512.h
+++ b/hash/api/ascon_avx512.h
@@ -20,13 +20,15 @@
 #ifndef ASCON_AVX512
 #define ASCON_AVX512
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_ascon_256_avx512;
-extern const struct lc_hash *lc_ascon_128a_avx512;
-extern const struct lc_hash *lc_ascon_xof_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_256_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_128a_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_xof_avx512;
 
 #ifdef __cplusplus
 }

--- a/hash/api/ascon_c.h
+++ b/hash/api/ascon_c.h
@@ -20,13 +20,15 @@
 #ifndef ASCON_C
 #define ASCON_C
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_ascon_256_c;
-extern const struct lc_hash *lc_ascon_128a_c;
-extern const struct lc_hash *lc_ascon_xof_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_256_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_128a_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_xof_c;
 
 #ifdef __cplusplus
 }

--- a/hash/api/lc_ascon_hash.h.in
+++ b/hash/api/lc_ascon_hash.h.in
@@ -20,6 +20,7 @@
 #ifndef LC_ASCON_HASH_H
 #define LC_ASCON_HASH_H
 
+#include "lc_export.h"
 #include "lc_hash.h"
 
 #ifdef __cplusplus
@@ -74,19 +75,19 @@ struct lc_ascon_hash {
  * @var lc_ascon_256
  * @brief Ascon 256 message digest algorithm
  */
-extern const struct lc_hash *lc_ascon_256;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_256;
 
 /**
  * @var lc_ascon_128a
  * @brief Ascon 128a message digest algorithm
  */
-extern const struct lc_hash *lc_ascon_128a;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_128a;
 
 /**
  * @var lc_ascon_xof
  * @brief Ascon XOF extended output function
  */
-extern const struct lc_hash *lc_ascon_xof;
+extern LC_DLL_IMPORT const struct lc_hash *lc_ascon_xof;
 
 /**
  * @brief Allocate stack memory for the Ascon 256 context without VLA

--- a/hash/api/lc_sha256.h
+++ b/hash/api/lc_sha256.h
@@ -20,6 +20,7 @@
 #ifndef LC_SHA256_H
 #define LC_SHA256_H
 
+#include "lc_export.h"
 #include "lc_hash.h"
 
 #ifdef __cplusplus
@@ -30,7 +31,7 @@ extern "C" {
  * @var lc_sha256
  * @brief SHA2-256 algorithm reference
  */
-extern const struct lc_hash *lc_sha256;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHA256_SIZE_BLOCK 64

--- a/hash/api/lc_sha3.h
+++ b/hash/api/lc_sha3.h
@@ -20,6 +20,7 @@
 #ifndef LC_SHA3_H
 #define LC_SHA3_H
 
+#include "lc_export.h"
 #include "lc_hash.h"
 
 #ifdef __cplusplus
@@ -57,7 +58,7 @@ struct lc_sha3_state {
  * @var lc_sha3_224
  * @brief SHA3-224 algorithm reference
  */
-extern const struct lc_hash *lc_sha3_224;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHA3_224_SIZE_DIGEST_BITS 224
@@ -94,7 +95,7 @@ extern const struct lc_hash *lc_sha3_224;
  * @var lc_sha3_256
  * @brief SHA3-256 algorithm reference
  */
-extern const struct lc_hash *lc_sha3_256;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHA3_256_SIZE_DIGEST_BITS 256
@@ -131,7 +132,7 @@ extern const struct lc_hash *lc_sha3_256;
  * @var lc_sha3_384
  * @brief SHA3-384 algorithm reference
  */
-extern const struct lc_hash *lc_sha3_384;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHA3_384_SIZE_DIGEST_BITS 384
@@ -168,7 +169,7 @@ extern const struct lc_hash *lc_sha3_384;
  * @var lc_sha3_512
  * @brief SHA3-512 algorithm reference
  */
-extern const struct lc_hash *lc_sha3_512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHA3_512_SIZE_DIGEST_BITS 512
@@ -205,7 +206,7 @@ extern const struct lc_hash *lc_sha3_512;
  * @var lc_shake128
  * @brief SHAKE128 algorithm reference
  */
-extern const struct lc_hash *lc_shake128;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHAKE_128_SIZE_DIGEST_BITS 128
@@ -241,7 +242,7 @@ extern const struct lc_hash *lc_shake128;
  * @var lc_shake256
  * @brief SHAKE256 algorithm reference
  */
-extern const struct lc_hash *lc_shake256;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHAKE_256_SIZE_DIGEST_BITS 256
@@ -276,7 +277,7 @@ extern const struct lc_hash *lc_shake256;
  * @var lc_shake512
  * @brief SHAKE512 algorithm reference
  */
-extern const struct lc_hash *lc_shake512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHAKE_512_SIZE_DIGEST_BITS 512
@@ -311,7 +312,7 @@ extern const struct lc_hash *lc_shake512;
  * @var lc_cshake256
  * @brief cSHAKE256 algorithm reference
  */
-extern const struct lc_hash *lc_cshake256;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256;
 
 /// \cond DO_NOT_DOCUMENT
 
@@ -342,7 +343,7 @@ extern const struct lc_hash *lc_cshake256;
  * @var lc_cshake128
  * @brief cSHAKE128 algorithm reference
  */
-extern const struct lc_hash *lc_cshake128;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_CSHAKE_128_CTX(name)                                                \

--- a/hash/api/lc_sha512.h
+++ b/hash/api/lc_sha512.h
@@ -20,6 +20,7 @@
 #ifndef LC_SHA512_H
 #define LC_SHA512_H
 
+#include "lc_export.h"
 #include "lc_hash.h"
 
 #ifdef __cplusplus
@@ -30,13 +31,13 @@ extern "C" {
  * @var lc_sha384
  * @brief SHA2-384 algorithm reference
  */
-extern const struct lc_hash *lc_sha384;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384;
 
 /**
  * @var lc_sha512
  * @brief SHA2-512 algorithm reference
  */
-extern const struct lc_hash *lc_sha512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_SHA512_SIZE_BLOCK 128

--- a/hash/api/sha256_arm_ce.h
+++ b/hash/api/sha256_arm_ce.h
@@ -20,11 +20,13 @@
 #ifndef SHA256_ARM_CE_H
 #define SHA256_ARM_CE_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha256_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256_arm_ce;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha256_arm_neon.h
+++ b/hash/api/sha256_arm_neon.h
@@ -20,11 +20,13 @@
 #ifndef SHA256_ARM_NEON_H
 #define SHA256_ARM_NEON_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha256_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256_arm_neon;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha256_avx2.h
+++ b/hash/api/sha256_avx2.h
@@ -20,11 +20,13 @@
 #ifndef SHA256_AVX2_H
 #define SHA256_AVX2_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha256_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256_avx2;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha256_c.h
+++ b/hash/api/sha256_c.h
@@ -20,11 +20,13 @@
 #ifndef SHA256_C_H
 #define SHA256_C_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha256_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256_c;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha256_riscv.h
+++ b/hash/api/sha256_riscv.h
@@ -20,11 +20,13 @@
 #ifndef SHA256_RISCV_H
 #define SHA256_RISCV_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha256_riscv;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256_riscv;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha256_riscv_zbb.h
+++ b/hash/api/sha256_riscv_zbb.h
@@ -20,11 +20,13 @@
 #ifndef SHA256_RISCV_ZBB_H
 #define SHA256_RISCV_ZBB_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha256_riscv_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256_riscv_zbb;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha256_shani.h
+++ b/hash/api/sha256_shani.h
@@ -20,11 +20,13 @@
 #ifndef SHA256_SHANI_H
 #define SHA256_SHANI_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha256_shani;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha256_shani;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha3_arm_asm.h
+++ b/hash/api/sha3_arm_asm.h
@@ -20,20 +20,22 @@
 #ifndef SHA3_ARM_ASM_H
 #define SHA3_ARM_ASM_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha3_224_arm_asm;
-extern const struct lc_hash *lc_sha3_256_arm_asm;
-extern const struct lc_hash *lc_sha3_384_arm_asm;
-extern const struct lc_hash *lc_sha3_512_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_arm_asm;
 
-extern const struct lc_hash *lc_shake128_arm_asm;
-extern const struct lc_hash *lc_shake256_arm_asm;
-extern const struct lc_hash *lc_shake512_arm_asm;
-extern const struct lc_hash *lc_cshake128_arm_asm;
-extern const struct lc_hash *lc_cshake256_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_arm_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_arm_asm;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha3_arm_ce.h
+++ b/hash/api/sha3_arm_ce.h
@@ -20,20 +20,22 @@
 #ifndef SHA3_ARM_CE_H
 #define SHA3_ARM_CE_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha3_224_arm_ce;
-extern const struct lc_hash *lc_sha3_256_arm_ce;
-extern const struct lc_hash *lc_sha3_384_arm_ce;
-extern const struct lc_hash *lc_sha3_512_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_arm_ce;
 
-extern const struct lc_hash *lc_shake128_arm_ce;
-extern const struct lc_hash *lc_shake256_arm_ce;
-extern const struct lc_hash *lc_shake512_arm_ce;
-extern const struct lc_hash *lc_cshake128_arm_ce;
-extern const struct lc_hash *lc_cshake256_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_arm_ce;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha3_arm_neon.h
+++ b/hash/api/sha3_arm_neon.h
@@ -20,20 +20,22 @@
 #ifndef SHA3_ARM_NEON_H
 #define SHA3_ARM_NEON_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha3_224_arm_neon;
-extern const struct lc_hash *lc_sha3_256_arm_neon;
-extern const struct lc_hash *lc_sha3_384_arm_neon;
-extern const struct lc_hash *lc_sha3_512_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_arm_neon;
 
-extern const struct lc_hash *lc_shake128_arm_neon;
-extern const struct lc_hash *lc_shake256_arm_neon;
-extern const struct lc_hash *lc_shake512_arm_neon;
-extern const struct lc_hash *lc_cshake128_arm_neon;
-extern const struct lc_hash *lc_cshake256_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_arm_neon;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha3_avx2.h
+++ b/hash/api/sha3_avx2.h
@@ -20,20 +20,22 @@
 #ifndef SHA3_AVX2_H
 #define SHA3_AVX2_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha3_224_avx2;
-extern const struct lc_hash *lc_sha3_256_avx2;
-extern const struct lc_hash *lc_sha3_384_avx2;
-extern const struct lc_hash *lc_sha3_512_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_avx2;
 
-extern const struct lc_hash *lc_shake128_avx2;
-extern const struct lc_hash *lc_shake256_avx2;
-extern const struct lc_hash *lc_shake512_avx2;
-extern const struct lc_hash *lc_cshake128_avx2;
-extern const struct lc_hash *lc_cshake256_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_avx2;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha3_avx512.h
+++ b/hash/api/sha3_avx512.h
@@ -20,20 +20,22 @@
 #ifndef SHA3_AVX512_H
 #define SHA3_AVX512_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha3_224_avx512;
-extern const struct lc_hash *lc_sha3_256_avx512;
-extern const struct lc_hash *lc_sha3_384_avx512;
-extern const struct lc_hash *lc_sha3_512_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_avx512;
 
-extern const struct lc_hash *lc_shake128_avx512;
-extern const struct lc_hash *lc_shake256_avx512;
-extern const struct lc_hash *lc_shake512_avx512;
-extern const struct lc_hash *lc_cshake128_avx512;
-extern const struct lc_hash *lc_cshake256_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_avx512;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_avx512;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha3_c.h
+++ b/hash/api/sha3_c.h
@@ -20,20 +20,22 @@
 #ifndef SHA3_C_H
 #define SHA3_C_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha3_224_c;
-extern const struct lc_hash *lc_sha3_256_c;
-extern const struct lc_hash *lc_sha3_384_c;
-extern const struct lc_hash *lc_sha3_512_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_c;
 
-extern const struct lc_hash *lc_shake128_c;
-extern const struct lc_hash *lc_shake256_c;
-extern const struct lc_hash *lc_shake512_c;
-extern const struct lc_hash *lc_cshake128_c;
-extern const struct lc_hash *lc_cshake256_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_c;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha3_riscv_asm.h
+++ b/hash/api/sha3_riscv_asm.h
@@ -20,31 +20,33 @@
 #ifndef SHA3_RISCV_ASM_H
 #define SHA3_RISCV_ASM_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha3_224_riscv_asm;
-extern const struct lc_hash *lc_sha3_256_riscv_asm;
-extern const struct lc_hash *lc_sha3_384_riscv_asm;
-extern const struct lc_hash *lc_sha3_512_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_riscv_asm;
 
-extern const struct lc_hash *lc_shake128_riscv_asm;
-extern const struct lc_hash *lc_shake256_riscv_asm;
-extern const struct lc_hash *lc_shake512_riscv_asm;
-extern const struct lc_hash *lc_cshake128_riscv_asm;
-extern const struct lc_hash *lc_cshake256_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_riscv_asm;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_riscv_asm;
 
-extern const struct lc_hash *lc_sha3_224_riscv_asm_zbb;
-extern const struct lc_hash *lc_sha3_256_riscv_asm_zbb;
-extern const struct lc_hash *lc_sha3_384_riscv_asm_zbb;
-extern const struct lc_hash *lc_sha3_512_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_224_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_256_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_384_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha3_512_riscv_asm_zbb;
 
-extern const struct lc_hash *lc_shake128_riscv_asm_zbb;
-extern const struct lc_hash *lc_shake256_riscv_asm_zbb;
-extern const struct lc_hash *lc_shake512_riscv_asm_zbb;
-extern const struct lc_hash *lc_cshake128_riscv_asm_zbb;
-extern const struct lc_hash *lc_cshake256_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake128_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake256_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_shake512_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake128_riscv_asm_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_cshake256_riscv_asm_zbb;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha512_arm_ce.h
+++ b/hash/api/sha512_arm_ce.h
@@ -20,12 +20,14 @@
 #ifndef SHA512_ARM_CE_H
 #define SHA512_ARM_CE_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha384_arm_ce;
-extern const struct lc_hash *lc_sha512_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384_arm_ce;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512_arm_ce;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha512_arm_neon.h
+++ b/hash/api/sha512_arm_neon.h
@@ -20,12 +20,14 @@
 #ifndef SHA512_ARM_NEON_H
 #define SHA512_ARM_NEON_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha384_arm_neon;
-extern const struct lc_hash *lc_sha512_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384_arm_neon;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512_arm_neon;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha512_avx2.h
+++ b/hash/api/sha512_avx2.h
@@ -20,12 +20,14 @@
 #ifndef SHA512_AVX2_H
 #define SHA512_AVX2_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha384_avx2;
-extern const struct lc_hash *lc_sha512_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384_avx2;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512_avx2;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha512_c.h
+++ b/hash/api/sha512_c.h
@@ -20,12 +20,14 @@
 #ifndef SHA512_C_H
 #define SHA512_C_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha384_c;
-extern const struct lc_hash *lc_sha512_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384_c;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512_c;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha512_riscv.h
+++ b/hash/api/sha512_riscv.h
@@ -20,12 +20,14 @@
 #ifndef SHA512_RISCV_H
 #define SHA512_RISCV_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha384_riscv;
-extern const struct lc_hash *lc_sha512_riscv;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384_riscv;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512_riscv;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha512_riscv_zbb.h
+++ b/hash/api/sha512_riscv_zbb.h
@@ -20,12 +20,14 @@
 #ifndef SHA512_RISCV_ZBB_H
 #define SHA512_RISCV_ZBB_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha384_riscv_zbb;
-extern const struct lc_hash *lc_sha512_riscv_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384_riscv_zbb;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512_riscv_zbb;
 
 #ifdef __cplusplus
 }

--- a/hash/api/sha512_shani.h
+++ b/hash/api/sha512_shani.h
@@ -20,12 +20,14 @@
 #ifndef SHA512_SHANI_H
 #define SHA512_SHANI_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_hash *lc_sha384_shani;
-extern const struct lc_hash *lc_sha512_shani;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha384_shani;
+extern LC_DLL_IMPORT const struct lc_hash *lc_sha512_shani;
 
 #ifdef __cplusplus
 }

--- a/hash/src/asm/AVX2/sha2-256-AVX2.h
+++ b/hash/src/asm/AVX2/sha2-256-AVX2.h
@@ -27,10 +27,10 @@
 extern "C" {
 #endif
 
-void sha256_block_data_order_avx2(struct lc_sha256_state *c, const uint8_t *p,
-				  size_t num);
-void sha256_block_data_order_shaext(struct lc_sha256_state *c, const uint8_t *p,
-				    size_t num);
+void SYSV_ABI sha256_block_data_order_avx2(struct lc_sha256_state *c,
+					   const uint8_t *p, size_t num);
+void SYSV_ABI sha256_block_data_order_shaext(struct lc_sha256_state *c,
+					     const uint8_t *p, size_t num);
 
 #ifdef __cplusplus
 }

--- a/hash/src/asm/AVX2/sha2-512-AVX2.h
+++ b/hash/src/asm/AVX2/sha2-512-AVX2.h
@@ -27,10 +27,10 @@
 extern "C" {
 #endif
 
-void sha512_block_data_order_avx2(struct lc_sha512_state *c, const uint8_t *p,
-				  size_t num);
-void sha512_block_data_order_shaext(struct lc_sha512_state *c, const uint8_t *p,
-				    size_t num);
+void SYSV_ABI sha512_block_data_order_avx2(struct lc_sha512_state *c,
+					   const uint8_t *p, size_t num);
+void SYSV_ABI sha512_block_data_order_shaext(struct lc_sha512_state *c,
+					     const uint8_t *p, size_t num);
 
 #ifdef __cplusplus
 }

--- a/hash/src/asm/AVX512/KeccakP-1600-SnP.h
+++ b/hash/src/asm/AVX512/KeccakP-1600-SnP.h
@@ -43,8 +43,14 @@
 #define KeccakP1600_AVX512_StaticInitialize()
 void SYSV_ABI KeccakP1600_AVX512_Initialize(void *state);
 //void KeccakP1600_AVX512_AddByte(void *state, unsigned char data, unsigned int offset);
-static inline void KeccakP1600_AVX512_AddByte(void *state, unsigned char byte,
-					      unsigned int offset)
+/*
+ * Although implemented in C, the function is handed over to the assembler glue
+ * code together with the assembler implementations and therefore must use the
+ * same ABI as those - see SYSV_ABI.
+ */
+static inline void SYSV_ABI KeccakP1600_AVX512_AddByte(void *state,
+						       unsigned char byte,
+						       unsigned int offset)
 {
 	((unsigned char *)(state))[(offset)] ^= (byte);
 }
@@ -57,8 +63,8 @@ void SYSV_ABI KeccakP1600_AVX512_OverwriteBytes(void *state,
 						unsigned int length);
 void SYSV_ABI KeccakP1600_AVX512_OverwriteWithZeroes(void *state,
 						     unsigned int byteCount);
-void SYSV_ABI SYSV_ABI KeccakP1600_AVX512_Permute_Nrounds(void *state,
-							  unsigned int nrounds);
+void SYSV_ABI KeccakP1600_AVX512_Permute_Nrounds(void *state,
+						 unsigned int nrounds);
 void SYSV_ABI KeccakP1600_AVX512_Permute_12rounds(void *state);
 void SYSV_ABI KeccakP1600_AVX512_Permute_24rounds(void *state);
 void SYSV_ABI KeccakP1600_AVX512_ExtractBytes(const void *state,

--- a/hash/src/keccak_asm_glue.h
+++ b/hash/src/keccak_asm_glue.h
@@ -39,6 +39,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #define KECCAK_ASM_GLUE_H
 
 #include "build_bug_on.h"
+#include "ext_headers.h"
 #include "lc_sha3.h"
 #include "sha3_common.h"
 
@@ -48,6 +49,30 @@ http://creativecommons.org/publicdomain/zero/1.0/
 extern "C" {
 #endif
 
+/*
+ * The assembler implementations of the Keccak permutation follow the SysV ABI
+ * on all systems - see SYSV_ABI. The calling convention is part of the function
+ * type, i.e. it must be carried by the function pointers the implementations
+ * are handed over with as well. Without it, the indirect calls below are issued
+ * with the ABI of the host on systems where both differ - notably Windows,
+ * where the arguments would be passed in the wrong registers.
+ */
+typedef void(SYSV_ABI *keccak_static_initialize_f)(void);
+typedef void(SYSV_ABI *keccak_initialize_f)(void *state);
+typedef void(SYSV_ABI *keccak_permute_f)(void *state);
+typedef void(SYSV_ABI *keccak_add_byte_f)(void *state, unsigned char data,
+					  unsigned int offset);
+typedef void(SYSV_ABI *keccak_add_bytes_f)(void *state,
+					   const unsigned char *data,
+					   size_t offset, size_t length);
+typedef void(SYSV_ABI *keccak_extract_bytes_f)(const void *state,
+					       unsigned char *data,
+					       size_t offset, size_t length);
+typedef size_t(SYSV_ABI *keccak_fastloop_absorb_f)(void *state,
+						   unsigned int laneCount,
+						   const unsigned char *data,
+						   size_t dataByteLen);
+
 /**
  * StaticInitialize - Function called at least once before any use of the other
  * functions, possibly to initialize global variables.
@@ -56,9 +81,9 @@ extern "C" {
  * Initialize - Function to initialize the state to the logical value 0^width.
  * @param _state   Pointer to the state to initialize.
  */
-static inline void sha3_224_asm_init(void *_state,
-				     void (*StaticInitialize)(void),
-				     void (*Initialize)(void *state))
+static inline void
+sha3_224_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		  keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -72,9 +97,9 @@ static inline void sha3_224_asm_init(void *_state,
 	sha3_224_init_common(_state);
 }
 
-static inline void sha3_256_asm_init(void *_state,
-				     void (*StaticInitialize)(void),
-				     void (*Initialize)(void *state))
+static inline void
+sha3_256_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		  keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -88,9 +113,9 @@ static inline void sha3_256_asm_init(void *_state,
 	sha3_256_init_common(_state);
 }
 
-static inline void sha3_384_asm_init(void *_state,
-				     void (*StaticInitialize)(void),
-				     void (*Initialize)(void *state))
+static inline void
+sha3_384_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		  keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -104,9 +129,9 @@ static inline void sha3_384_asm_init(void *_state,
 	sha3_384_init_common(_state);
 }
 
-static inline void sha3_512_asm_init(void *_state,
-				     void (*StaticInitialize)(void),
-				     void (*Initialize)(void *state))
+static inline void
+sha3_512_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		  keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -120,9 +145,9 @@ static inline void sha3_512_asm_init(void *_state,
 	sha3_512_init_common(_state);
 }
 
-static inline void shake_128_asm_init(void *_state,
-				      void (*StaticInitialize)(void),
-				      void (*Initialize)(void *state))
+static inline void
+shake_128_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		   keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -136,9 +161,9 @@ static inline void shake_128_asm_init(void *_state,
 	shake_128_init_common(_state);
 }
 
-static inline void shake_256_asm_init(void *_state,
-				      void (*StaticInitialize)(void),
-				      void (*Initialize)(void *state))
+static inline void
+shake_256_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		   keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -152,9 +177,9 @@ static inline void shake_256_asm_init(void *_state,
 	shake_256_init_common(_state);
 }
 
-static inline void shake_512_asm_init(void *_state,
-				      void (*StaticInitialize)(void),
-				      void (*Initialize)(void *state))
+static inline void
+shake_512_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		   keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -168,9 +193,9 @@ static inline void shake_512_asm_init(void *_state,
 	shake_512_init_common(_state);
 }
 
-static inline void cshake_128_asm_init(void *_state,
-				       void (*StaticInitialize)(void),
-				       void (*Initialize)(void *state))
+static inline void
+cshake_128_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		    keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -184,9 +209,9 @@ static inline void cshake_128_asm_init(void *_state,
 	cshake_128_init_common(_state);
 }
 
-static inline void cshake_256_asm_init(void *_state,
-				       void (*StaticInitialize)(void),
-				       void (*Initialize)(void *state))
+static inline void
+cshake_256_asm_init(void *_state, keccak_static_initialize_f StaticInitialize,
+		    keccak_initialize_f Initialize)
 {
 	struct lc_sha3_state *ctx = _state;
 
@@ -235,14 +260,10 @@ static inline void cshake_256_asm_init(void *_state,
  * return    The number of bytes processed.
  * pre    0 < @a laneCount < SnP_laneCount
  */
-static inline void
-keccak_asm_absorb(void *_state, const uint8_t *in, size_t inlen,
-		  void (*AddBytes)(void *state, const unsigned char *data,
-				   size_t offset, size_t length),
-		  void (*Permute)(void *state),
-		  size_t (*FastLoop_Absorb)(void *state, unsigned int laneCount,
-					    const unsigned char *data,
-					    size_t dataByteLen))
+static inline void keccak_asm_absorb(void *_state, const uint8_t *in,
+				     size_t inlen, keccak_add_bytes_f AddBytes,
+				     keccak_permute_f Permute,
+				     keccak_fastloop_absorb_f FastLoop_Absorb)
 {
 	/*
 	 * All lc_sha3_*_state are equal except for the last entry, thus we use
@@ -313,10 +334,9 @@ keccak_asm_absorb(void *_state, const uint8_t *in, size_t inlen,
 	ctx->partial = (uint8_t)inlen;
 }
 
-static inline void keccak_asm_absorb_last_bits(
-	void *_state,
-	void (*AddByte)(void *state, unsigned char data, unsigned int offset),
-	void (*Permute)(void *state))
+static inline void keccak_asm_absorb_last_bits(void *_state,
+					       keccak_add_byte_f AddByte,
+					       keccak_permute_f Permute)
 {
 	/*
 	 * All lc_sha3_*_state are equal except for the last entry, thus we use
@@ -380,12 +400,10 @@ static inline void keccak_asm_absorb_last_bits(
  * pre    0 ≤ @a offset < (width in bytes)
  * pre    0 ≤ @a offset + @a length ≤ (width in bytes)
  */
-static inline void keccak_asm_squeeze(
-	void *_state, uint8_t *digest,
-	void (*AddByte)(void *state, unsigned char data, unsigned int offset),
-	void (*Permute)(void *state),
-	void (*ExtractBytes)(const void *state, unsigned char *data,
-			     size_t offset, size_t length))
+static inline void keccak_asm_squeeze(void *_state, uint8_t *digest,
+				      keccak_add_byte_f AddByte,
+				      keccak_permute_f Permute,
+				      keccak_extract_bytes_f ExtractBytes)
 {
 	/*
 	 * All lc_sha3_*_state are equal except for the last entry, thus we use

--- a/hash/src/sha256.c
+++ b/hash/src/sha256.c
@@ -161,8 +161,8 @@ static inline void sha256_transform(struct lc_sha256_state *ctx,
 		W[i] = 0;
 }
 
-static inline void sha256_transform_block_c(struct lc_sha256_state *ctx,
-					    const uint8_t *in, size_t blocks)
+static inline void SYSV_ABI sha256_transform_block_c(
+	struct lc_sha256_state *ctx, const uint8_t *in, size_t blocks)
 {
 	size_t i;
 
@@ -170,10 +170,9 @@ static inline void sha256_transform_block_c(struct lc_sha256_state *ctx,
 		sha256_transform(ctx, in);
 }
 
-void lc_sha256_update(
-	struct lc_sha256_state *ctx, const uint8_t *in, size_t inlen,
-	void (*sha256_transform_block)(struct lc_sha256_state *ctx,
-				       const uint8_t *in, size_t blocks))
+void lc_sha256_update(struct lc_sha256_state *ctx, const uint8_t *in,
+		      size_t inlen,
+		      sha256_transform_block_f sha256_transform_block)
 {
 	size_t blocks;
 	unsigned int partial;
@@ -236,9 +235,7 @@ static void sha256_update_c(void *_state, const uint8_t *in, size_t inlen)
 }
 
 void lc_sha256_final(struct lc_sha256_state *ctx, uint8_t *digest,
-		     void (*sha256_transform_block)(struct lc_sha256_state *ctx,
-						    const uint8_t *in,
-						    size_t blocks))
+		     sha256_transform_block_f sha256_transform_block)
 {
 	unsigned int i, partial;
 

--- a/hash/src/sha2_common.h
+++ b/hash/src/sha2_common.h
@@ -20,6 +20,7 @@
 #ifndef SHA2_COMMON_H
 #define SHA2_COMMON_H
 
+#include "ext_headers.h"
 #include "lc_sha256.h"
 #include "lc_sha512.h"
 
@@ -27,18 +28,34 @@
 extern "C" {
 #endif
 
+/*
+ * The assembler implementations of the transformation follow the SysV ABI on
+ * all systems - see SYSV_ABI. The calling convention is part of the function
+ * type, i.e. it must be carried by the function pointers the implementations
+ * are handed over with as well. Without it, the indirect calls in
+ * lc_sha*_update and lc_sha*_final are issued with the ABI of the host on
+ * systems where both differ - notably Windows, where the arguments would be
+ * passed in the wrong registers and the assembler code would clobber the
+ * registers the caller expects to be preserved.
+ *
+ * The implementations written in C are therefore given the same ABI.
+ */
+typedef void(SYSV_ABI *sha256_transform_block_f)(struct lc_sha256_state *ctx,
+						 const uint8_t *in,
+						 size_t blocks);
+typedef void(SYSV_ABI *sha512_transform_block_f)(struct lc_sha512_state *ctx,
+						 const uint8_t *in,
+						 size_t blocks);
+
 int lc_sha256_init(void *_state);
 int lc_sha256_init_nocheck(void *_state);
 
-void lc_sha256_update(
-	struct lc_sha256_state *ctx, const uint8_t *in, size_t inlen,
-	void (*sha256_transform_block)(struct lc_sha256_state *ctx,
-				       const uint8_t *in, size_t blocks));
+void lc_sha256_update(struct lc_sha256_state *ctx, const uint8_t *in,
+		      size_t inlen,
+		      sha256_transform_block_f sha256_transform_block);
 
 void lc_sha256_final(struct lc_sha256_state *ctx, uint8_t *digest,
-		     void (*sha256_transform_block)(struct lc_sha256_state *ctx,
-						    const uint8_t *in,
-						    size_t blocks));
+		     sha256_transform_block_f sha256_transform_block);
 
 size_t lc_sha256_get_digestsize(const void *_state);
 
@@ -49,18 +66,13 @@ int lc_sha384_init_nocheck(void *_state);
 int lc_sha512_init(void *_state);
 int lc_sha512_init_nocheck(void *_state);
 
-void lc_sha512_update(
-	struct lc_sha512_state *ctx, const uint8_t *in, size_t inlen,
-	void (*sha512_transform_block)(struct lc_sha512_state *ctx,
-				       const uint8_t *in, size_t blocks));
+void lc_sha512_update(struct lc_sha512_state *ctx, const uint8_t *in,
+		      size_t inlen,
+		      sha512_transform_block_f sha512_transform_block);
 void lc_sha384_final(struct lc_sha512_state *ctx, uint8_t *digest,
-		     void (*sha512_transform_block)(struct lc_sha512_state *ctx,
-						    const uint8_t *in,
-						    size_t blocks));
+		     sha512_transform_block_f sha512_transform_block);
 void lc_sha512_final(struct lc_sha512_state *ctx, uint8_t *digest,
-		     void (*sha512_transform_block)(struct lc_sha512_state *ctx,
-						    const uint8_t *in,
-						    size_t blocks));
+		     sha512_transform_block_f sha512_transform_block);
 void lc_sha512_extract_bytes(const void *state, uint8_t *data, size_t offset,
 			     size_t length);
 size_t lc_sha384_get_digestsize(const void *_state);

--- a/hash/src/sha3_avx2.c
+++ b/hash/src/sha3_avx2.c
@@ -29,11 +29,7 @@
 
 static int sha3_224_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_224_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -48,11 +44,7 @@ static int sha3_224_avx2_init(void *_state)
 
 static int sha3_256_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_256_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -67,11 +59,7 @@ static int sha3_256_avx2_init(void *_state)
 
 static int sha3_384_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_384_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -86,11 +74,7 @@ static int sha3_384_avx2_init(void *_state)
 
 static int sha3_512_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_512_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -105,11 +89,7 @@ static int sha3_512_avx2_init(void *_state)
 
 static int shake_128_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	shake_128_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -124,11 +104,7 @@ static int shake_128_avx2_init(void *_state)
 
 static int shake_256_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	shake_256_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -143,11 +119,7 @@ static int shake_256_avx2_init(void *_state)
 
 static int shake_512_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	shake_512_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -162,11 +134,7 @@ static int shake_512_avx2_init(void *_state)
 
 static int cshake_128_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	cshake_128_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -181,11 +149,7 @@ static int cshake_128_avx2_init(void *_state)
 
 static int cshake_256_avx2_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	cshake_256_asm_init(_state, NULL, KeccakP1600_AVX2_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -201,26 +165,18 @@ static int cshake_256_avx2_init(void *_state)
 static void keccak_avx2_absorb(void *_state, const uint8_t *in, size_t inlen)
 {
 	LC_FPU_ENABLE;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	keccak_asm_absorb(_state, in, inlen, KeccakP1600_AVX2_AddBytes,
 			  KeccakP1600_AVX2_Permute_24rounds,
 			  KeccakF1600_AVX2_FastLoop_Absorb);
-#pragma GCC diagnostic pop
 	LC_FPU_DISABLE;
 }
 
 static void keccak_avx2_squeeze(void *_state, uint8_t *digest)
 {
 	LC_FPU_ENABLE;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	keccak_asm_squeeze(_state, digest, KeccakP1600_AVX2_AddByte,
 			   KeccakP1600_AVX2_Permute_24rounds,
 			   KeccakP1600_AVX2_ExtractBytes);
-#pragma GCC diagnostic pop
 	LC_FPU_DISABLE;
 }
 

--- a/hash/src/sha3_avx512.c
+++ b/hash/src/sha3_avx512.c
@@ -29,11 +29,7 @@
 
 static int sha3_224_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_224_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -48,11 +44,7 @@ static int sha3_224_avx512_init(void *_state)
 
 static int sha3_256_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_256_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -67,11 +59,7 @@ static int sha3_256_avx512_init(void *_state)
 
 static int sha3_384_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_384_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -86,11 +74,7 @@ static int sha3_384_avx512_init(void *_state)
 
 static int sha3_512_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	sha3_512_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -105,11 +89,7 @@ static int sha3_512_avx512_init(void *_state)
 
 static int shake_128_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	shake_128_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -124,11 +104,7 @@ static int shake_128_avx512_init(void *_state)
 
 static int shake_256_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	shake_256_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -143,11 +119,7 @@ static int shake_256_avx512_init(void *_state)
 
 static int shake_512_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	shake_512_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -162,11 +134,7 @@ static int shake_512_avx512_init(void *_state)
 
 static int cshake_128_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	cshake_128_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -181,11 +149,7 @@ static int cshake_128_avx512_init(void *_state)
 
 static int cshake_256_avx512_init_nocheck(void *_state)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	cshake_256_asm_init(_state, NULL, KeccakP1600_AVX512_Initialize);
-#pragma GCC diagnostic pop
 
 	return 0;
 }
@@ -201,26 +165,18 @@ static int cshake_256_avx512_init(void *_state)
 static void keccak_avx512_absorb(void *_state, const uint8_t *in, size_t inlen)
 {
 	LC_FPU_ENABLE;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	keccak_asm_absorb(_state, in, inlen, KeccakP1600_AVX512_AddBytes,
 			  KeccakP1600_AVX512_Permute_24rounds,
 			  KeccakF1600_AVX512_FastLoop_Absorb);
-#pragma GCC diagnostic pop
 	LC_FPU_DISABLE;
 }
 
 static void keccak_avx512_squeeze(void *_state, uint8_t *digest)
 {
 	LC_FPU_ENABLE;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-	/* Handle SYSV_ABI */
 	keccak_asm_squeeze(_state, digest, KeccakP1600_AVX512_AddByte,
 			   KeccakP1600_AVX512_Permute_24rounds,
 			   KeccakP1600_AVX512_ExtractBytes);
-#pragma GCC diagnostic pop
 	LC_FPU_DISABLE;
 }
 

--- a/hash/src/sha512.c
+++ b/hash/src/sha512.c
@@ -209,8 +209,8 @@ static inline void sha512_transform(struct lc_sha512_state *ctx,
 		W[i] = 0;
 }
 
-static inline void sha512_transform_block_c(struct lc_sha512_state *ctx,
-					    const uint8_t *in, size_t blocks)
+static inline void SYSV_ABI sha512_transform_block_c(
+	struct lc_sha512_state *ctx, const uint8_t *in, size_t blocks)
 {
 	size_t i;
 
@@ -218,10 +218,9 @@ static inline void sha512_transform_block_c(struct lc_sha512_state *ctx,
 		sha512_transform(ctx, in);
 }
 
-void lc_sha512_update(
-	struct lc_sha512_state *ctx, const uint8_t *in, size_t inlen,
-	void (*sha512_transform_block)(struct lc_sha512_state *ctx,
-				       const uint8_t *in, size_t blocks))
+void lc_sha512_update(struct lc_sha512_state *ctx, const uint8_t *in,
+		      size_t inlen,
+		      sha512_transform_block_f sha512_transform_block)
 {
 	size_t blocks;
 	unsigned int partial;
@@ -283,10 +282,9 @@ static void sha512_update_c(void *_state, const uint8_t *in, size_t inlen)
 	lc_sha512_update(ctx, in, inlen, sha512_transform_block_c);
 }
 
-static int sha512_final_internal(
-	struct lc_sha512_state *ctx,
-	void (*sha512_transform_block)(struct lc_sha512_state *ctx,
-				       const uint8_t *in, size_t blocks))
+static int
+sha512_final_internal(struct lc_sha512_state *ctx,
+		      sha512_transform_block_f sha512_transform_block)
 {
 	unsigned int partial;
 
@@ -339,9 +337,7 @@ static int sha512_final_internal(
 }
 
 void lc_sha512_final(struct lc_sha512_state *ctx, uint8_t *digest,
-		     void (*sha512_transform_block)(struct lc_sha512_state *ctx,
-						    const uint8_t *in,
-						    size_t blocks))
+		     sha512_transform_block_f sha512_transform_block)
 {
 	unsigned int i;
 
@@ -359,9 +355,7 @@ void lc_sha512_final(struct lc_sha512_state *ctx, uint8_t *digest,
 }
 
 void lc_sha384_final(struct lc_sha512_state *ctx, uint8_t *digest,
-		     void (*sha512_transform_block)(struct lc_sha512_state *ctx,
-						    const uint8_t *in,
-						    size_t blocks))
+		     sha512_transform_block_f sha512_transform_block)
 {
 	unsigned int i;
 

--- a/internal/api/lc_export.h
+++ b/internal/api/lc_export.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026, Stephan Mueller <smueller@chronox.de>
+ *
+ * License: see LICENSE file in root directory
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef LC_EXPORT_H
+#define LC_EXPORT_H
+
+/*
+ * Windows requires the consumer of a DLL to reference exported *data* symbols
+ * through the import table. For function symbols the linker transparently
+ * generates a call thunk which is why they need no annotation. For data
+ * symbols no such indirection exists - without __declspec(dllimport) the
+ * reference is bound to the address of the (bogus) thunk the import library
+ * carries instead of to the variable itself, and the consumer operates on
+ * garbage at runtime.
+ *
+ * Therefore all data symbols defined with LC_INTERFACE_SYMBOL are exported as
+ * DATA in leancrypto.def and are declared with LC_DLL_IMPORT here.
+ *
+ * LC_LINK_SHARED is added to the compiler flags of everybody linking against
+ * the leancrypto DLL - see the leancrypto dependency object in meson.build and
+ * the Cflags of the generated pkg-config file. It is deliberately not set when
+ * leancrypto itself is compiled, nor when a consumer links against the static
+ * library, because in both cases the symbols are resolved directly.
+ *
+ * On all other systems the macro is empty.
+ */
+#if defined(LC_LINK_SHARED) && (defined(_WIN32) || defined(__CYGWIN__))
+#define LC_DLL_IMPORT __declspec(dllimport)
+#else
+#define LC_DLL_IMPORT
+#endif
+
+#endif /* LC_EXPORT_H */

--- a/internal/src/meson.build
+++ b/internal/src/meson.build
@@ -90,6 +90,7 @@ src += files([ 'memcmp_secure_c.c' ])
 
 include_files += files([
 	'../api/ext_headers.h',
+	'../api/lc_export.h',
 	'../api/lc_init.h',
 	'../api/lc_memcmp_secure.h',
 	'../api/lc_memcpy_secure.h',

--- a/kdf/api/lc_hkdf.h
+++ b/kdf/api/lc_hkdf.h
@@ -20,6 +20,7 @@
 #ifndef LC_HKDF_H
 #define LC_HKDF_H
 
+#include "lc_export.h"
 #include "ext_headers.h"
 #include "lc_hmac.h"
 #include "lc_rng.h"
@@ -240,7 +241,7 @@ enum lc_alg_status_val lc_hkdf_alg_status(const struct lc_hash *hash);
  */
 
 /* HKDF DRNG implementation */
-extern const struct lc_rng *lc_hkdf_rng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_hkdf_rng;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_HKDF_DRNG_CTX_SIZE                                                  \

--- a/kdf/api/lc_kdf_ctr.h
+++ b/kdf/api/lc_kdf_ctr.h
@@ -20,6 +20,7 @@
 #ifndef LC_KDF_CTR_H
 #define LC_KDF_CTR_H
 
+#include "lc_export.h"
 #include "ext_headers.h"
 #include "lc_hash.h"
 #include "lc_rng.h"
@@ -116,7 +117,7 @@ struct lc_kdf_ctr_ctx {
 	_LC_CTR_KDF_SET_CTX(name, hashname, name, sizeof(struct lc_kdf_ctr_ctx))
 
 /* CTR_KDF DRNG implementation */
-extern const struct lc_rng *lc_kdf_ctr_rng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_kdf_ctr_rng;
 
 #define LC_CTR_KDF_DRNG_CTX_SIZE                                               \
 	(sizeof(struct lc_rng_ctx) +                                           \

--- a/kmac/api/lc_kmac.h
+++ b/kmac/api/lc_kmac.h
@@ -20,6 +20,7 @@
 #ifndef LC_KMAC_H
 #define LC_KMAC_H
 
+#include "lc_export.h"
 #include "lc_hash.h"
 #include "lc_rng.h"
 #include "lc_sha3.h"
@@ -337,7 +338,7 @@ int lc_kmac_xof(const struct lc_hash *hash, const uint8_t *key, size_t keylen,
  */
 
 /* KMAC DRNG implementation */
-extern const struct lc_rng *lc_kmac_rng;
+extern LC_DLL_IMPORT const struct lc_rng *lc_kmac_rng;
 
 /// \cond DO_NOT_DOCUMENT
 #define LC_KMAC_KDF_DRNG_CTX_SIZE                                              \

--- a/leancrypto.def
+++ b/leancrypto.def
@@ -1,4 +1,3 @@
-LIBRARY leancrypto
 EXPORTS
 	; Interface functions defined with LC_INTERFACE_FUNCTION
 	; find ./ -name *.c | xargs grep LC_INTERFACE_FUNCTION | cut -d"," -f2 | uniq | sort
@@ -463,7 +462,7 @@ EXPORTS
 	lc_kex_x448_uake_responder_ss
 	lc_kh_alloc
 	lc_kmac
-	lc_kmac_rng
+	lc_kmac_rng DATA
 	lc_kmac256_drng_alloc
 	lc_kmac_alg_status
 	lc_kmac_alloc
@@ -847,181 +846,181 @@ EXPORTS
 
 	; Interface symbols
 	; find ./ -name *.c | xargs grep -A1 LC_INTERFACE_SYMBOL | cut -d"," -f2
-	lc_aes
-	lc_aes_aesni
-	lc_aes_armce
-	lc_aes_c
-	lc_aes_cbc
-	lc_aes_cbc_aesni
-	lc_aes_cbc_armce
-	lc_aes_cbc_c
-	lc_aes_cbc_riscv64
-	lc_aes_ct
-	lc_aes_ctr
-	lc_aes_ctr_aesni
-	lc_aes_ctr_armce
-	lc_aes_ctr_c
-	lc_aes_ctr_riscv64
+	lc_aes DATA
+	lc_aes_aesni DATA
+	lc_aes_armce DATA
+	lc_aes_c DATA
+	lc_aes_cbc DATA
+	lc_aes_cbc_aesni DATA
+	lc_aes_cbc_armce DATA
+	lc_aes_cbc_c DATA
+	lc_aes_cbc_riscv64 DATA
+	lc_aes_ct DATA
+	lc_aes_ctr DATA
+	lc_aes_ctr_aesni DATA
+	lc_aes_ctr_armce DATA
+	lc_aes_ctr_c DATA
+	lc_aes_ctr_riscv64 DATA
 	;lc_aes_ecb
-	lc_aes_gcm_aead
-	lc_aes_kw
-	lc_aes_kw_aesni
-	lc_aes_kw_armce
-	lc_aes_kw_c
-	lc_aes_kw_riscv64
-	lc_aes_riscv64
-	lc_aes_sbox
-	lc_aes_xts
-	lc_aes_xts_aesni
-	lc_aes_xts_armce
-	lc_aes_xts_c
-	lc_aes_xts_riscv64
-	lc_ascon_128a
-	lc_ascon_128a_arm_neon
-	lc_ascon_128a_avx512
-	lc_ascon_128a_c
-	lc_ascon_256
-	lc_ascon_256_arm_neon
-	lc_ascon_256_avx512
-	lc_ascon_256_c
-	lc_ascon_aead
-	lc_ascon_keccak_aead
-	lc_ascon_xof
-	lc_ascon_xof_arm_neon
-	lc_ascon_xof_avx512
-	lc_ascon_xof_c
-	lc_cc20_drng
-	lc_chacha20
-	lc_chacha20_avx2
-	lc_chacha20_avx512
-	lc_chacha20_c
-	lc_chacha20_neon
-	lc_chacha20_poly1305_aead
-	lc_chacha20_riscv64_v_zbb
-	lc_cshake128
-	lc_cshake128_arm_asm
-	lc_cshake128_arm_ce
-	lc_cshake128_arm_neon
-	lc_cshake128_avx2
-	lc_cshake128_avx512
-	lc_cshake128_c
-	lc_cshake128_riscv_asm
-	lc_cshake128_riscv_asm_zbb
-	lc_cshake256
-	lc_cshake256_arm_asm
-	lc_cshake256_arm_ce
-	lc_cshake256_arm_neon
-	lc_cshake256_avx2
-	lc_cshake256_avx512
-	lc_cshake256_c
-	lc_cshake256_drng
-	lc_cshake256_riscv_asm
-	lc_cshake256_riscv_asm_zbb
-	lc_cshake_aead
-	lc_ctr_drbg
-	lc_hash_aead
-	lc_hash_drbg
+	lc_aes_gcm_aead DATA
+	lc_aes_kw DATA
+	lc_aes_kw_aesni DATA
+	lc_aes_kw_armce DATA
+	lc_aes_kw_c DATA
+	lc_aes_kw_riscv64 DATA
+	lc_aes_riscv64 DATA
+	lc_aes_sbox DATA
+	lc_aes_xts DATA
+	lc_aes_xts_aesni DATA
+	lc_aes_xts_armce DATA
+	lc_aes_xts_c DATA
+	lc_aes_xts_riscv64 DATA
+	lc_ascon_128a DATA
+	lc_ascon_128a_arm_neon DATA
+	lc_ascon_128a_avx512 DATA
+	lc_ascon_128a_c DATA
+	lc_ascon_256 DATA
+	lc_ascon_256_arm_neon DATA
+	lc_ascon_256_avx512 DATA
+	lc_ascon_256_c DATA
+	lc_ascon_aead DATA
+	lc_ascon_keccak_aead DATA
+	lc_ascon_xof DATA
+	lc_ascon_xof_arm_neon DATA
+	lc_ascon_xof_avx512 DATA
+	lc_ascon_xof_c DATA
+	lc_cc20_drng DATA
+	lc_chacha20 DATA
+	lc_chacha20_avx2 DATA
+	lc_chacha20_avx512 DATA
+	lc_chacha20_c DATA
+	lc_chacha20_neon DATA
+	lc_chacha20_poly1305_aead DATA
+	lc_chacha20_riscv64_v_zbb DATA
+	lc_cshake128 DATA
+	lc_cshake128_arm_asm DATA
+	lc_cshake128_arm_ce DATA
+	lc_cshake128_arm_neon DATA
+	lc_cshake128_avx2 DATA
+	lc_cshake128_avx512 DATA
+	lc_cshake128_c DATA
+	lc_cshake128_riscv_asm DATA
+	lc_cshake128_riscv_asm_zbb DATA
+	lc_cshake256 DATA
+	lc_cshake256_arm_asm DATA
+	lc_cshake256_arm_ce DATA
+	lc_cshake256_arm_neon DATA
+	lc_cshake256_avx2 DATA
+	lc_cshake256_avx512 DATA
+	lc_cshake256_c DATA
+	lc_cshake256_drng DATA
+	lc_cshake256_riscv_asm DATA
+	lc_cshake256_riscv_asm_zbb DATA
+	lc_cshake_aead DATA
+	lc_ctr_drbg DATA
+	lc_hash_aead DATA
+	lc_hash_drbg DATA
 	lc_hkdf
-	lc_hkdf_rng
-	lc_hmac_drbg
+	lc_hkdf_rng DATA
+	lc_hmac_drbg DATA
 	lc_kdf_ctr
-	lc_kdf_ctr_rng
+	lc_kdf_ctr_rng DATA
 	lc_kmac
-	lc_kmac256_drng
-	lc_kmac_aead
-	lc_mode_cbc_c
-	lc_mode_ctr_c
-	lc_mode_xts_c
-	lc_seeded_rng
-	lc_sha256
-	lc_sha256_arm_ce
-	lc_sha256_arm_neon
-	lc_sha256_avx2
-	lc_sha256_c
-	lc_sha256_riscv
-	lc_sha256_riscv_zbb
-	lc_sha256_shani
-	lc_sha3_224
-	lc_sha3_224_arm_asm
-	lc_sha3_224_arm_ce
-	lc_sha3_224_arm_neon
-	lc_sha3_224_avx2
-	lc_sha3_224_avx512
-	lc_sha3_224_c
-	lc_sha3_224_riscv_asm
-	lc_sha3_224_riscv_asm_zbb
-	lc_sha3_256
-	lc_sha3_256_arm_asm
-	lc_sha3_256_arm_ce
-	lc_sha3_256_arm_neon
-	lc_sha3_256_avx2
-	lc_sha3_256_avx512
-	lc_sha3_256_c
-	lc_sha3_256_riscv_asm
-	lc_sha3_256_riscv_asm_zbb
-	lc_sha3_384
-	lc_sha3_384_arm_asm
-	lc_sha3_384_arm_ce
-	lc_sha3_384_arm_neon
-	lc_sha3_384_avx2
-	lc_sha3_384_avx512
-	lc_sha3_384_c
-	lc_sha3_384_riscv_asm
-	lc_sha3_384_riscv_asm_zbb
-	lc_sha3_512
-	lc_sha3_512_arm_asm
-	lc_sha3_512_arm_ce
-	lc_sha3_512_arm_neon
-	lc_sha3_512_avx2
-	lc_sha3_512_avx512
-	lc_sha3_512_c
-	lc_sha3_512_riscv_asm
-	lc_sha3_512_riscv_asm_zbb
-	lc_sha384
-	lc_sha384_arm_ce
-	lc_sha384_arm_neon
-	lc_sha384_avx2
-	lc_sha384_c
-	lc_sha384_riscv
-	lc_sha384_riscv_zbb
-	lc_sha384_shani
-	lc_sha512
-	lc_sha512_arm_ce
-	lc_sha512_arm_neon
-	lc_sha512_avx2
-	lc_sha512_c
-	lc_sha512_riscv
-	lc_sha512_riscv_zbb
-	lc_sha512_shani
-	lc_shake128
-	lc_shake128_arm_asm
-	lc_shake128_arm_ce
-	lc_shake128_arm_neon
-	lc_shake128_avx2
-	lc_shake128_avx512
-	lc_shake128_c
-	lc_shake128_riscv_asm
-	lc_shake128_riscv_asm_zbb
-	lc_shake256
-	lc_shake256_arm_asm
-	lc_shake256_arm_ce
-	lc_shake256_arm_neon
-	lc_shake256_avx2
-	lc_shake256_avx512
-	lc_shake256_c
-	lc_shake256_riscv_asm
-	lc_shake256_riscv_asm_zbb
-	lc_shake512
-	lc_shake512_arm_asm
-	lc_shake512_arm_ce
-	lc_shake512_arm_neon
-	lc_shake512_avx2
-	lc_shake512_avx512
-	lc_shake512_c
-	lc_shake512_riscv_asm
-	lc_shake512_riscv_asm_zbb
-	lc_symhmac_aead
-	lc_symkmac_aead
-	lc_xdrbg128_drng
-	lc_xdrbg256_drng
-	lc_xdrbg512_drng
+	lc_kmac256_drng DATA
+	lc_kmac_aead DATA
+	lc_mode_cbc_c DATA
+	lc_mode_ctr_c DATA
+	lc_mode_xts_c DATA
+	lc_seeded_rng DATA
+	lc_sha256 DATA
+	lc_sha256_arm_ce DATA
+	lc_sha256_arm_neon DATA
+	lc_sha256_avx2 DATA
+	lc_sha256_c DATA
+	lc_sha256_riscv DATA
+	lc_sha256_riscv_zbb DATA
+	lc_sha256_shani DATA
+	lc_sha3_224 DATA
+	lc_sha3_224_arm_asm DATA
+	lc_sha3_224_arm_ce DATA
+	lc_sha3_224_arm_neon DATA
+	lc_sha3_224_avx2 DATA
+	lc_sha3_224_avx512 DATA
+	lc_sha3_224_c DATA
+	lc_sha3_224_riscv_asm DATA
+	lc_sha3_224_riscv_asm_zbb DATA
+	lc_sha3_256 DATA
+	lc_sha3_256_arm_asm DATA
+	lc_sha3_256_arm_ce DATA
+	lc_sha3_256_arm_neon DATA
+	lc_sha3_256_avx2 DATA
+	lc_sha3_256_avx512 DATA
+	lc_sha3_256_c DATA
+	lc_sha3_256_riscv_asm DATA
+	lc_sha3_256_riscv_asm_zbb DATA
+	lc_sha3_384 DATA
+	lc_sha3_384_arm_asm DATA
+	lc_sha3_384_arm_ce DATA
+	lc_sha3_384_arm_neon DATA
+	lc_sha3_384_avx2 DATA
+	lc_sha3_384_avx512 DATA
+	lc_sha3_384_c DATA
+	lc_sha3_384_riscv_asm DATA
+	lc_sha3_384_riscv_asm_zbb DATA
+	lc_sha3_512 DATA
+	lc_sha3_512_arm_asm DATA
+	lc_sha3_512_arm_ce DATA
+	lc_sha3_512_arm_neon DATA
+	lc_sha3_512_avx2 DATA
+	lc_sha3_512_avx512 DATA
+	lc_sha3_512_c DATA
+	lc_sha3_512_riscv_asm DATA
+	lc_sha3_512_riscv_asm_zbb DATA
+	lc_sha384 DATA
+	lc_sha384_arm_ce DATA
+	lc_sha384_arm_neon DATA
+	lc_sha384_avx2 DATA
+	lc_sha384_c DATA
+	lc_sha384_riscv DATA
+	lc_sha384_riscv_zbb DATA
+	lc_sha384_shani DATA
+	lc_sha512 DATA
+	lc_sha512_arm_ce DATA
+	lc_sha512_arm_neon DATA
+	lc_sha512_avx2 DATA
+	lc_sha512_c DATA
+	lc_sha512_riscv DATA
+	lc_sha512_riscv_zbb DATA
+	lc_sha512_shani DATA
+	lc_shake128 DATA
+	lc_shake128_arm_asm DATA
+	lc_shake128_arm_ce DATA
+	lc_shake128_arm_neon DATA
+	lc_shake128_avx2 DATA
+	lc_shake128_avx512 DATA
+	lc_shake128_c DATA
+	lc_shake128_riscv_asm DATA
+	lc_shake128_riscv_asm_zbb DATA
+	lc_shake256 DATA
+	lc_shake256_arm_asm DATA
+	lc_shake256_arm_ce DATA
+	lc_shake256_arm_neon DATA
+	lc_shake256_avx2 DATA
+	lc_shake256_avx512 DATA
+	lc_shake256_c DATA
+	lc_shake256_riscv_asm DATA
+	lc_shake256_riscv_asm_zbb DATA
+	lc_shake512 DATA
+	lc_shake512_arm_asm DATA
+	lc_shake512_arm_ce DATA
+	lc_shake512_arm_neon DATA
+	lc_shake512_avx2 DATA
+	lc_shake512_avx512 DATA
+	lc_shake512_c DATA
+	lc_shake512_riscv_asm DATA
+	lc_shake512_riscv_asm_zbb DATA
+	lc_symhmac_aead DATA
+	lc_symkmac_aead DATA
+	lc_xdrbg128_drng DATA
+	lc_xdrbg256_drng DATA
+	lc_xdrbg512_drng DATA

--- a/meson.build
+++ b/meson.build
@@ -1013,6 +1013,17 @@ if host_machine.system() == 'windows'
 	arch_src += files([ 'internal/src/getopt.c' ])
 endif
 
+# clang-cl preprocesses an assembler source into an intermediate file that is
+# named after the source and that is placed into the current working directory
+# instead of into a unique temporary location. An assembler source compiled more
+# than once - as done for the individual ML-KEM and ML-DSA parameter sets - thus
+# lets the concurrently running compilations overwrite each other's intermediate
+# which silently yields two objects holding the symbols of one parameter set.
+# Compile a uniquely named copy of such a source to keep the intermediates
+# apart.
+asm_unique_copy = (host_machine.system() == 'windows' and
+		   cc.get_argument_syntax() == 'msvc')
+
 # FIPS non-approved crypto sources
 src = [ ]
 
@@ -1198,22 +1209,35 @@ else
 	leancrypto_lib_fips = leancrypto_static_lib_fips
 endif
 
+# Windows requires the consumer of a DLL to declare the imported data symbols
+# with __declspec(dllimport) - see internal/api/lc_export.h. The flag is only
+# handed out with the dependency object of the shared library. Consumers of the
+# static library resolve the symbols directly and thus must not see it.
+leancrypto_shared_cargs = [ ]
+if (build_shared and host_machine.system() == 'windows')
+	leancrypto_shared_cargs += [ '-DLC_LINK_SHARED' ]
+endif
+
 if get_option('efi').disabled()
 	pkgconfig.generate(leancrypto_lib_fips,
+			extra_cflags: leancrypto_shared_cargs,
 			description: 'PQC-resistant cryptographic library with FIPS-140 compliance')
 endif
 
 leancrypto_fips = declare_dependency(link_with: leancrypto_lib_fips,
 				     dependencies: [ leancrypto_ssp_link ],
+				     compile_args: leancrypto_shared_cargs,
 				     include_directories: include_dirs)
 
 if get_option('efi').disabled()
 	pkgconfig.generate(leancrypto_lib,
+			   extra_cflags: leancrypto_shared_cargs,
 			   description: 'PQC-resistant cryptographic library')
 endif
 
 leancrypto = declare_dependency(link_with: leancrypto_lib,
 				dependencies: [ leancrypto_ssp_link ],
+				compile_args: leancrypto_shared_cargs,
 				include_directories: include_dirs)
 
 install_headers(include_files, subdir: leancrypto_header_subdir)

--- a/ml-dsa/src/avx2/meson.build
+++ b/ml-dsa/src/avx2/meson.build
@@ -9,14 +9,10 @@ endif
 
 # Files which are compiled for each Dilithium implementation separately
 dilithium_avx2 = files([
-	'dilithium_invntt_avx2.S',
-	'dilithium_ntt_avx2.S',
-	'dilithium_pointwise_avx2.S',
 	'dilithium_poly_avx2.c',
 	'dilithium_polyvec_avx2.c',
 	'dilithium_rejsample_avx2.c',
 	'dilithium_rounding_avx2.c',
-	'dilithium_shuffle_avx2.S',
 ])
 
 if get_option('dilithium_keygen').enabled()
@@ -29,10 +25,35 @@ if get_option('dilithium_sigver').enabled()
 	dilithium_avx2 += files([ 'dilithium_signature_sigver_avx2.c' ])
 endif
 
+# Assembler files which are compiled for each Dilithium implementation
+# separately - see asm_unique_copy why they need a per-implementation name
+dilithium_avx2_asm = [
+	'dilithium_invntt_avx2.S',
+	'dilithium_ntt_avx2.S',
+	'dilithium_pointwise_avx2.S',
+	'dilithium_shuffle_avx2.S',
+]
+
+dilithium_87_avx2 = dilithium_avx2
+dilithium_65_avx2 = dilithium_avx2
+foreach f : dilithium_avx2_asm
+	if asm_unique_copy
+		dilithium_87_avx2 += configure_file(input: f,
+						    output: 'dilithium_87_' + f,
+						    copy: true)
+		dilithium_65_avx2 += configure_file(input: f,
+						    output: 'dilithium_65_' + f,
+						    copy: true)
+	else
+		dilithium_87_avx2 += files(f)
+		dilithium_65_avx2 += files(f)
+	endif
+endforeach
+
 if get_option('dilithium_87').enabled()
 	leancrypto_dilithium_87_avx2_lib = static_library(
 			'leancrypto_dilithium_87_avx2_lib',
-			[ dilithium_avx2 ],
+			[ dilithium_87_avx2 ],
 			include_directories: [
 				'../',
 				include_dirs,
@@ -46,7 +67,7 @@ endif
 if get_option('dilithium_65').enabled()
 	leancrypto_dilithium_65_avx2_lib = static_library(
 			'leancrypto_dilithium_65_avx2_lib',
-			[ dilithium_avx2 ],
+			[ dilithium_65_avx2 ],
 			include_directories: [
 				'../',
 				include_dirs,

--- a/ml-kem/src/avx2/meson.build
+++ b/ml-kem/src/avx2/meson.build
@@ -8,16 +8,37 @@ kyber_avx2_common = files([
 
 # Files which are compiled for each Kyber implementation separately
 kyber_avx2 = files([
-	'kyber_basemul_avx2.S',
-	'kyber_fq_avx2.S',
 	'kyber_indcpa_avx2.c',
-	'kyber_invntt_avx2.S',
 	'kyber_kem_avx2.c',
-	'kyber_ntt_avx2.S',
 	'kyber_poly_avx2.c',
 	'kyber_rejsample_avx2.c',
-	'kyber_shuffle_avx2.S',
 ])
+
+# Assembler files which are compiled for each Kyber implementation separately -
+# see asm_unique_copy why they need a per-implementation name
+kyber_avx2_asm = [
+	'kyber_basemul_avx2.S',
+	'kyber_fq_avx2.S',
+	'kyber_invntt_avx2.S',
+	'kyber_ntt_avx2.S',
+	'kyber_shuffle_avx2.S',
+]
+
+kyber_1024_avx2 = kyber_avx2
+kyber_768_avx2 = kyber_avx2
+foreach f : kyber_avx2_asm
+	if asm_unique_copy
+		kyber_1024_avx2 += configure_file(input: f,
+						  output: 'kyber_1024_' + f,
+						  copy: true)
+		kyber_768_avx2 += configure_file(input: f,
+						 output: 'kyber_768_' + f,
+						 copy: true)
+	else
+		kyber_1024_avx2 += files(f)
+		kyber_768_avx2 += files(f)
+	endif
+endforeach
 
 if (get_option('kyber_1024').enabled() or get_option('kyber_768').enabled())
 	leancrypto_kyber_common_avx2_lib = static_library(
@@ -36,7 +57,7 @@ endif
 if get_option('kyber_1024').enabled()
 	leancrypto_kyber_1024_avx2_lib = static_library(
 			'leancrypto_kyber_1024_avx2_lib',
-			[ kyber_avx2 ],
+			[ kyber_1024_avx2 ],
 			include_directories: [
 				'../',
 				include_dirs,
@@ -50,7 +71,7 @@ endif
 if get_option('kyber_768').enabled()
 	leancrypto_kyber_768_avx2_lib = static_library(
 			'leancrypto_kyber_768_avx2_lib',
-			[ kyber_avx2 ],
+			[ kyber_768_avx2 ],
 			include_directories: [
 				'../',
 				include_dirs,

--- a/sym/api/aes_aesni.h
+++ b/sym/api/aes_aesni.h
@@ -20,15 +20,17 @@
 #ifndef AES_AESNI_H
 #define AES_AESNI_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_aes_cbc_aesni;
-extern const struct lc_sym *lc_aes_ctr_aesni;
-extern const struct lc_sym *lc_aes_kw_aesni;
-extern const struct lc_sym *lc_aes_aesni;
-extern const struct lc_sym *lc_aes_xts_aesni;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_cbc_aesni;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_ctr_aesni;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_kw_aesni;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_aesni;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_xts_aesni;
 
 #ifdef __cplusplus
 }

--- a/sym/api/aes_armce.h
+++ b/sym/api/aes_armce.h
@@ -20,15 +20,17 @@
 #ifndef AES_ARMCE_V8_H
 #define AES_ARMCE_V8_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_aes_cbc_armce;
-extern const struct lc_sym *lc_aes_ctr_armce;
-extern const struct lc_sym *lc_aes_kw_armce;
-extern const struct lc_sym *lc_aes_armce;
-extern const struct lc_sym *lc_aes_xts_armce;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_cbc_armce;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_ctr_armce;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_kw_armce;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_armce;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_xts_armce;
 
 #ifdef __cplusplus
 }

--- a/sym/api/aes_c.h
+++ b/sym/api/aes_c.h
@@ -20,18 +20,20 @@
 #ifndef AES_C_H
 #define AES_C_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_aes_cbc_c;
-extern const struct lc_sym *lc_aes_ctr_c;
-extern const struct lc_sym *lc_aes_kw_c;
-extern const struct lc_sym *lc_aes_c;
-extern const struct lc_sym *lc_aes_xts_c;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_cbc_c;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_ctr_c;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_kw_c;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_c;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_xts_c;
 
-extern const struct lc_sym *lc_aes_sbox;
-extern const struct lc_sym *lc_aes_ct;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_sbox;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_ct;
 #ifdef __cplusplus
 }
 #endif

--- a/sym/api/aes_riscv64.h
+++ b/sym/api/aes_riscv64.h
@@ -20,16 +20,18 @@
 #ifndef AES_RISCV64_V8_H
 #define AES_RISCV64_V8_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_aes_cbc_riscv64;
-extern const struct lc_sym *lc_aes_ctr_riscv64;
-extern const struct lc_sym *lc_aes_kw_riscv64;
-extern const struct lc_sym *lc_aes_riscv64;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_cbc_riscv64;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_ctr_riscv64;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_kw_riscv64;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_riscv64;
 extern const struct lc_sym *lc_aes_riscv64_enc_only;
-extern const struct lc_sym *lc_aes_xts_riscv64;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_xts_riscv64;
 
 #ifdef __cplusplus
 }

--- a/sym/api/chacha20_avx2.h
+++ b/sym/api/chacha20_avx2.h
@@ -20,11 +20,13 @@
 #ifndef CHACHA20_AVX2_H
 #define CHACHA20_AVX2_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_chacha20_avx2;
+extern LC_DLL_IMPORT const struct lc_sym *lc_chacha20_avx2;
 
 #ifdef __cplusplus
 }

--- a/sym/api/chacha20_avx512.h
+++ b/sym/api/chacha20_avx512.h
@@ -20,11 +20,13 @@
 #ifndef CHACHA20_AVX512_H
 #define CHACHA20_AVX512_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_chacha20_avx512;
+extern LC_DLL_IMPORT const struct lc_sym *lc_chacha20_avx512;
 
 #ifdef __cplusplus
 }

--- a/sym/api/chacha20_c.h
+++ b/sym/api/chacha20_c.h
@@ -20,11 +20,13 @@
 #ifndef CHACHA20_C_H
 #define CHACHA20_C_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_chacha20_c;
+extern LC_DLL_IMPORT const struct lc_sym *lc_chacha20_c;
 
 #ifdef __cplusplus
 }

--- a/sym/api/chacha20_neon.h
+++ b/sym/api/chacha20_neon.h
@@ -20,11 +20,13 @@
 #ifndef CHACHA20_NEON_H
 #define CHACHA20_NEON_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_chacha20_neon;
+extern LC_DLL_IMPORT const struct lc_sym *lc_chacha20_neon;
 
 #ifdef __cplusplus
 }

--- a/sym/api/chacha20_riscv64_v_zbb.h
+++ b/sym/api/chacha20_riscv64_v_zbb.h
@@ -20,11 +20,13 @@
 #ifndef CHACHA20_RISCV64_V_ZBB_H
 #define CHACHA20_RISCV64_V_ZBB_H
 
+#include "lc_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_chacha20_riscv64_v_zbb;
+extern LC_DLL_IMPORT const struct lc_sym *lc_chacha20_riscv64_v_zbb;
 
 #ifdef __cplusplus
 }

--- a/sym/api/lc_aes.h
+++ b/sym/api/lc_aes.h
@@ -26,6 +26,7 @@
 #ifndef LC_AES_H
 #define LC_AES_H
 
+#include "lc_export.h"
 #include "lc_sym.h"
 
 #ifdef __cplusplus
@@ -33,22 +34,22 @@ extern "C" {
 #endif
 
 /* AES ECB mode */
-extern const struct lc_sym *lc_aes_ecb;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_ecb;
 
 /* AES CBC mode */
-extern const struct lc_sym *lc_aes_cbc;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_cbc;
 
 /* AES CTR mode */
-extern const struct lc_sym *lc_aes_ctr;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_ctr;
 
 /* AES KW mode */
-extern const struct lc_sym *lc_aes_kw;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_kw;
 
 /* AES raw block operation */
-extern const struct lc_sym *lc_aes;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes;
 
 /* AES XTS mode */
-extern const struct lc_sym *lc_aes_xts;
+extern LC_DLL_IMPORT const struct lc_sym *lc_aes_xts;
 
 /**
  * @ingroup Symmetric

--- a/sym/api/lc_chacha20.h
+++ b/sym/api/lc_chacha20.h
@@ -20,13 +20,14 @@
 #ifndef LC_CHACHA20_H
 #define LC_CHACHA20_H
 
+#include "lc_export.h"
 #include "lc_sym.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern const struct lc_sym *lc_chacha20;
+extern LC_DLL_IMPORT const struct lc_sym *lc_chacha20;
 
 #define LC_CC20_STATE_SIZE (144)
 

--- a/sym/src/mode_cbc.h
+++ b/sym/src/mode_cbc.h
@@ -20,6 +20,7 @@
 #ifndef MODE_CBC_H
 #define MODE_CBC_H
 
+#include "lc_export.h"
 #include "lc_sym.h"
 
 #ifdef __cplusplus
@@ -34,7 +35,7 @@ struct lc_mode_state {
 
 void mode_cbc_selftest(const struct lc_sym *aes);
 
-extern const struct lc_sym_mode *lc_mode_cbc_c;
+extern LC_DLL_IMPORT const struct lc_sym_mode *lc_mode_cbc_c;
 
 #ifdef __cplusplus
 }

--- a/sym/src/mode_ctr.h
+++ b/sym/src/mode_ctr.h
@@ -20,6 +20,7 @@
 #ifndef MODE_CTR_H
 #define MODE_CTR_H
 
+#include "lc_export.h"
 #include "aes_internal.h"
 #include "bitshift.h"
 #include "build_bug_on.h"
@@ -40,7 +41,7 @@ struct lc_mode_state {
 
 void mode_ctr_selftest(const struct lc_sym *aes);
 
-extern const struct lc_sym_mode *lc_mode_ctr_c;
+extern LC_DLL_IMPORT const struct lc_sym_mode *lc_mode_ctr_c;
 
 static inline void ctr128_inc(uint64_t ctr[AES_CTR128_64BIT_WORDS])
 {

--- a/sym/src/mode_xts.h
+++ b/sym/src/mode_xts.h
@@ -20,6 +20,7 @@
 #ifndef MODE_XTS_H
 #define MODE_XTS_H
 
+#include "lc_export.h"
 #include "conv_be_le.h"
 #include "lc_sym.h"
 
@@ -79,7 +80,7 @@ static inline void gfmul_alpha(union lc_xts_tweak *t)
 
 void mode_xts_selftest(const struct lc_sym *aes);
 
-extern const struct lc_sym_mode *lc_mode_xts_c;
+extern LC_DLL_IMPORT const struct lc_sym_mode *lc_mode_xts_c;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Notes while looking at this:
- the __declspec(dllimport) and __declspec(dllexport) are may not necessary, if the def file is correct (see https://learn.microsoft.com/en-us/cpp/build/importing-and-exporting?view=msvc-170)
- The DLL linking also needs to be checked in jitterentropy. I'll do this.